### PR TITLE
Adding a Catalog Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ eye2eye-*.tar
 npm-debug.log
 /assets/node_modules/
 
+.vscode
+.idea
+.DS_Store
+.elixir_ls

--- a/lib/eye2eye/catalog.ex
+++ b/lib/eye2eye/catalog.ex
@@ -1,0 +1,104 @@
+defmodule Eye2eye.Catalog do
+  @moduledoc """
+  The Catalog context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Eye2eye.Repo
+
+  alias Eye2eye.Catalog.Product
+
+  @doc """
+  Returns the list of products.
+
+  ## Examples
+
+      iex> list_products()
+      [%Product{}, ...]
+
+  """
+  def list_products do
+    Repo.all(Product)
+  end
+
+  @doc """
+  Gets a single product.
+
+  Raises `Ecto.NoResultsError` if the Product does not exist.
+
+  ## Examples
+
+      iex> get_product!(123)
+      %Product{}
+
+      iex> get_product!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_product!(id), do: Repo.get!(Product, id)
+
+  @doc """
+  Creates a product.
+
+  ## Examples
+
+      iex> create_product(%{field: value})
+      {:ok, %Product{}}
+
+      iex> create_product(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_product(attrs \\ %{}) do
+    %Product{}
+    |> Product.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a product.
+
+  ## Examples
+
+      iex> update_product(product, %{field: new_value})
+      {:ok, %Product{}}
+
+      iex> update_product(product, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_product(%Product{} = product, attrs) do
+    product
+    |> Product.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a product.
+
+  ## Examples
+
+      iex> delete_product(product)
+      {:ok, %Product{}}
+
+      iex> delete_product(product)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_product(%Product{} = product) do
+    Repo.delete(product)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking product changes.
+
+  ## Examples
+
+      iex> change_product(product)
+      %Ecto.Changeset{data: %Product{}}
+
+  """
+  def change_product(%Product{} = product, attrs \\ %{}) do
+    Product.changeset(product, attrs)
+  end
+end

--- a/lib/eye2eye/catalog/product.ex
+++ b/lib/eye2eye/catalog/product.ex
@@ -1,0 +1,19 @@
+defmodule Eye2eye.Catalog.Product do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "products" do
+    field :image_url, :string
+    field :name, :string
+    field :price, :decimal
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(product, attrs) do
+    product
+    |> cast(attrs, [:name, :image_url, :price])
+    |> validate_required([:name, :image_url, :price ])
+  end
+end

--- a/lib/eye2eye_web/controllers/product_controller.ex
+++ b/lib/eye2eye_web/controllers/product_controller.ex
@@ -1,0 +1,12 @@
+defmodule Eye2eyeWeb.ProductController do
+  use Eye2eyeWeb, :controller
+
+  alias Eye2eye.Catalog
+  alias Eye2eye.Catalog.Product
+
+  def index(conn, _params) do
+    products = Catalog.list_products()
+    render(conn, "index.html", products: products)
+  end
+
+end

--- a/lib/eye2eye_web/router.ex
+++ b/lib/eye2eye_web/router.ex
@@ -17,7 +17,7 @@ defmodule Eye2eyeWeb.Router do
   scope "/", Eye2eyeWeb do
     pipe_through :browser
 
-    get "/", PageController, :index
+    get "/", ProductController, :index
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20220824190920_create_products.exs
+++ b/priv/repo/migrations/20220824190920_create_products.exs
@@ -1,0 +1,13 @@
+defmodule Eye2eye.Repo.Migrations.CreateProducts do
+  use Ecto.Migration
+
+  def change do
+    create table(:products) do
+      add :name, :string
+      add :image_url, :string
+      add :price, :decimal, precision: 15, scale: 2, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,30 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias Eye2eye.Repo
+alias Eye2eye.Catalog
+alias Eye2eye.Catalog.Product
+
+Repo.delete_all(Product)
+
+for i <- 1..10 do
+  img_url = [
+    "https://images.unsplash.com/photo-1574258495973-f010dfbb5371?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2370&q=80",
+    "https://images.unsplash.com/photo-1603578119639-798b8413d8d7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
+    "https://images.unsplash.com/photo-1582478134397-2b32c067e22d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
+    "https://images.unsplash.com/photo-1589176449149-71f7ea77ec25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80",
+    "https://images.unsplash.com/photo-1534844978-b859e5a09ad6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1674&q=80",
+    "https://images.unsplash.com/photo-1619089661769-3101dbac9257?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1728&q=80",
+    "https://images.unsplash.com/photo-1475312775467-159e03aaa7cd?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
+    "https://images.unsplash.com/photo-1511499767150-a48a237f0083?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1180&q=80",
+    "https://images.unsplash.com/photo-1483412468200-72182dbbc544?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1773&q=80",
+    "https://images.unsplash.com/photo-1542629458-eaa56d608062?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1767&q=80"
+  ]
+  {:ok, _} =
+    Catalog.create_product(%{
+      name: "Product #{i}",
+      image_url: "#{Enum.at(img_url, i-1)}",
+      price: "#{100 + i}",
+    })
+end

--- a/test/eye2eye/catalog_test.exs
+++ b/test/eye2eye/catalog_test.exs
@@ -22,13 +22,13 @@ defmodule Eye2eye.CatalogTest do
 
     test "create_product/1 with valid data creates a product" do
       valid_attrs = %{
-        image_url: "some image_url",
+        image_url: "https://images.unsplash.com/photo",
         name: "some name",
         price: "120.50",
       }
 
       assert {:ok, %Product{} = product} = Catalog.create_product(valid_attrs)
-      assert product.image_url == "some image_url"
+      assert product.image_url == "https://images.unsplash.com/photo"
       assert product.name == "some name"
       assert product.price == Decimal.new("120.50")
     end
@@ -41,13 +41,13 @@ defmodule Eye2eye.CatalogTest do
       product = product_fixture()
 
       update_attrs = %{
-        image_url: "some updated image_url",
+        image_url: "https://images.unsplash.com/photo2",
         name: "some updated name",
         price: "456.70",
       }
 
       assert {:ok, %Product{} = product} = Catalog.update_product(product, update_attrs)
-      assert product.image_url == "some updated image_url"
+      assert product.image_url == "https://images.unsplash.com/photo2"
       assert product.name == "some updated name"
       assert product.price == Decimal.new("456.70")
     end

--- a/test/eye2eye/catalog_test.exs
+++ b/test/eye2eye/catalog_test.exs
@@ -1,0 +1,72 @@
+defmodule Eye2eye.CatalogTest do
+  use Eye2eye.DataCase
+
+  alias Eye2eye.Catalog
+
+  describe "products" do
+    alias Eye2eye.Catalog.Product
+
+    import Eye2eye.CatalogFixtures
+
+    @invalid_attrs %{image_url: nil, name: nil, price: nil}
+
+    test "list_products/0 returns all products" do
+      product = product_fixture()
+      assert Catalog.list_products() == [product]
+    end
+
+    test "get_product!/1 returns the product with given id" do
+      product = product_fixture()
+      assert Catalog.get_product!(product.id) == product
+    end
+
+    test "create_product/1 with valid data creates a product" do
+      valid_attrs = %{
+        image_url: "some image_url",
+        name: "some name",
+        price: "120.50",
+      }
+
+      assert {:ok, %Product{} = product} = Catalog.create_product(valid_attrs)
+      assert product.image_url == "some image_url"
+      assert product.name == "some name"
+      assert product.price == Decimal.new("120.50")
+    end
+
+    test "create_product/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Catalog.create_product(@invalid_attrs)
+    end
+
+    test "update_product/2 with valid data updates the product" do
+      product = product_fixture()
+
+      update_attrs = %{
+        image_url: "some updated image_url",
+        name: "some updated name",
+        price: "456.70",
+      }
+
+      assert {:ok, %Product{} = product} = Catalog.update_product(product, update_attrs)
+      assert product.image_url == "some updated image_url"
+      assert product.name == "some updated name"
+      assert product.price == Decimal.new("456.70")
+    end
+
+    test "update_product/2 with invalid data returns error changeset" do
+      product = product_fixture()
+      assert {:error, %Ecto.Changeset{}} = Catalog.update_product(product, @invalid_attrs)
+      assert product == Catalog.get_product!(product.id)
+    end
+
+    test "delete_product/1 deletes the product" do
+      product = product_fixture()
+      assert {:ok, %Product{}} = Catalog.delete_product(product)
+      assert_raise Ecto.NoResultsError, fn -> Catalog.get_product!(product.id) end
+    end
+
+    test "change_product/1 returns a product changeset" do
+      product = product_fixture()
+      assert %Ecto.Changeset{} = Catalog.change_product(product)
+    end
+  end
+end

--- a/test/eye2eye_web/controllers/product_controller_test.exs
+++ b/test/eye2eye_web/controllers/product_controller_test.exs
@@ -1,0 +1,15 @@
+defmodule Eye2eyeWeb.ProductControllerTest do
+  use Eye2eyeWeb.ConnCase
+
+  alias Eye2eye.Catalog
+
+  import Eye2eye.CatalogFixtures
+
+  describe "index" do
+    test "lists all ", %{conn: conn} do
+      conn = get(conn, Routes.product_path(conn, :index))
+      assert html_response(conn, 200) =~ "Summer 2022 Collection"
+    end
+  end
+
+end

--- a/test/support/fixtures/catalog_fixtures.ex
+++ b/test/support/fixtures/catalog_fixtures.ex
@@ -1,0 +1,22 @@
+defmodule Eye2eye.CatalogFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Eye2eye.Catalog` context.
+  """
+
+  @doc """
+  Generate a product.
+  """
+  def product_fixture(attrs \\ %{}) do
+    {:ok, product} =
+      attrs
+      |> Enum.into(%{
+        image_url: "some image_url",
+        name: "some name",
+        price: "120.50",
+      })
+      |> Eye2eye.Catalog.create_product()
+
+    product
+  end
+end


### PR DESCRIPTION
This PR relates to [this ticket](https://trello.com/c/Waq5gVWO/16-adding-a-catalog-context)

Contexts are dedicated modules that expose and group related functionality. They encapsulate data access and data validation and talk to a database or APIs.

Context name: Catalog
Ecto schema name: Product
Postgres db table name: products
Postgres db field name and type:

name:string
image_url:string
price:decimal 

