### PR TITLE
Cleanup code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This is the final capstone project of the [8th Light Apprenticeship](https://8th
   - [Run tests](#run-tests)
   - [Project requirements](#project-requirements)
   - [Implementation requirements](#implementation-requirements)
-  - [File Structure](#file-structure)
   - [Learn more](#learn-more)
 
 ## Prerequisites
@@ -34,7 +33,7 @@ To start your Phoenix server:
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
-***Note:** You can delete your database with `mix ecto.drop`, but make sure your server has stopped before you run the command.*
+***Note:** You can delete your database with `mix ecto.drop`, but make sure your server has stopped before you run the command. To view all the routes for the application run `mix phx.routes`
 
 Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
 
@@ -65,51 +64,6 @@ Since this is the first iteration of the app, the UI should be clear and functio
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
-## File Structure
-#### Overview
-├── _build 
-├── assets
-├── config
-├── deps
-├── lib
-│   ├── eye2eye
-│   ├── eye2eye_web
-│   ├── eye2eye_web.ex
-│   └── eye2eye.ex
-├── priv
-└── test
-
-#### Business domain
-lib/eye2eye
-├── catalog.ex
-│   └── product.ex
-├── application.ex
-├── catalog.ex
-├── mailer.ex
-└── repo.ex
-
-#### Web-related parts of our application
-lib/eye2eye_web
-├── controllers
-│   └── product_controller.ex
-├── templates
-│   ├── layout
-│   │   ├── app.html.heex
-│   │   ├── live.html.heex
-│   │   └── root.html.heex
-│   └── product
-│       └── index.html.heex
-├── views
-│   ├── error_helpers.ex
-│   ├── error_view.ex
-│   ├── layout_view.ex
-│   └── product_view.ex
-├── endpoint.ex
-├── gettext.ex
-├── router.ex
-└── telemetry.ex
-
-<p align="right">(<a href="#top">back to top</a>)</p>
 ## Learn more
 
   * Official website: https://www.phoenixframework.org/
@@ -119,3 +73,7 @@ lib/eye2eye_web
   * Source: https://github.com/phoenixframework/phoenix
 
 <p align="right">(<a href="#top">back to top</a>)</p>
+
+## Author
+
+Safia Ali 

--- a/lib/eye2eye/catalog.ex
+++ b/lib/eye2eye/catalog.ex
@@ -22,22 +22,6 @@ defmodule Eye2eye.Catalog do
   end
 
   @doc """
-  Gets a single product.
-
-  Raises `Ecto.NoResultsError` if the Product does not exist.
-
-  ## Examples
-
-      iex> get_product!(123)
-      %Product{}
-
-      iex> get_product!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_product!(id), do: Repo.get!(Product, id)
-
-  @doc """
   Creates a product.
 
   ## Examples
@@ -53,52 +37,5 @@ defmodule Eye2eye.Catalog do
     %Product{}
     |> Product.changeset(attrs)
     |> Repo.insert()
-  end
-
-  @doc """
-  Updates a product.
-
-  ## Examples
-
-      iex> update_product(product, %{field: new_value})
-      {:ok, %Product{}}
-
-      iex> update_product(product, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def update_product(%Product{} = product, attrs) do
-    product
-    |> Product.changeset(attrs)
-    |> Repo.update()
-  end
-
-  @doc """
-  Deletes a product.
-
-  ## Examples
-
-      iex> delete_product(product)
-      {:ok, %Product{}}
-
-      iex> delete_product(product)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_product(%Product{} = product) do
-    Repo.delete(product)
-  end
-
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking product changes.
-
-  ## Examples
-
-      iex> change_product(product)
-      %Ecto.Changeset{data: %Product{}}
-
-  """
-  def change_product(%Product{} = product, attrs \\ %{}) do
-    Product.changeset(product, attrs)
   end
 end

--- a/test/eye2eye/catalog_test.exs
+++ b/test/eye2eye/catalog_test.exs
@@ -15,11 +15,6 @@ defmodule Eye2eye.CatalogTest do
       assert Catalog.list_products() == [product]
     end
 
-    test "get_product!/1 returns the product with given id" do
-      product = product_fixture()
-      assert Catalog.get_product!(product.id) == product
-    end
-
     test "create_product/1 with valid data creates a product" do
       valid_attrs = %{
         image_url: "https://images.unsplash.com/photo",
@@ -35,38 +30,6 @@ defmodule Eye2eye.CatalogTest do
 
     test "create_product/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Catalog.create_product(@invalid_attrs)
-    end
-
-    test "update_product/2 with valid data updates the product" do
-      product = product_fixture()
-
-      update_attrs = %{
-        image_url: "https://images.unsplash.com/photo2",
-        name: "some updated name",
-        price: "456.70"
-      }
-
-      assert {:ok, %Product{} = product} = Catalog.update_product(product, update_attrs)
-      assert product.image_url == "https://images.unsplash.com/photo2"
-      assert product.name == "some updated name"
-      assert product.price == Decimal.new("456.70")
-    end
-
-    test "update_product/2 with invalid data returns error changeset" do
-      product = product_fixture()
-      assert {:error, %Ecto.Changeset{}} = Catalog.update_product(product, @invalid_attrs)
-      assert product == Catalog.get_product!(product.id)
-    end
-
-    test "delete_product/1 deletes the product" do
-      product = product_fixture()
-      assert {:ok, %Product{}} = Catalog.delete_product(product)
-      assert_raise Ecto.NoResultsError, fn -> Catalog.get_product!(product.id) end
-    end
-
-    test "change_product/1 returns a product changeset" do
-      product = product_fixture()
-      assert %Ecto.Changeset{} = Catalog.change_product(product)
     end
   end
 end


### PR DESCRIPTION
This PR focuses on removing methods relating to calls to db in the `catalog` context, such as query by product id, update, delete products along with their tests. 

It also included changes to README due to not displaying correcting. Will update this at a later stage