### PR TITLE
Add shopping cart context

### DIFF
--- a/lib/eye2eye/shopping_cart.ex
+++ b/lib/eye2eye/shopping_cart.ex
@@ -1,0 +1,104 @@
+defmodule Eye2eye.ShoppingCart do
+  @moduledoc """
+  The ShoppingCart context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Eye2eye.Repo
+
+  alias Eye2eye.ShoppingCart.Cart
+
+  @doc """
+  Returns the list of carts.
+
+  ## Examples
+
+      iex> list_carts()
+      [%Cart{}, ...]
+
+  """
+  def list_carts do
+    Repo.all(Cart)
+  end
+
+  @doc """
+  Gets a single cart.
+
+  Raises `Ecto.NoResultsError` if the Cart does not exist.
+
+  ## Examples
+
+      iex> get_cart!(123)
+      %Cart{}
+
+      iex> get_cart!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_cart!(id), do: Repo.get!(Cart, id)
+
+  @doc """
+  Creates a cart.
+
+  ## Examples
+
+      iex> create_cart(%{field: value})
+      {:ok, %Cart{}}
+
+      iex> create_cart(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_cart(attrs \\ %{}) do
+    %Cart{}
+    |> Cart.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a cart.
+
+  ## Examples
+
+      iex> update_cart(cart, %{field: new_value})
+      {:ok, %Cart{}}
+
+      iex> update_cart(cart, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_cart(%Cart{} = cart, attrs) do
+    cart
+    |> Cart.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a cart.
+
+  ## Examples
+
+      iex> delete_cart(cart)
+      {:ok, %Cart{}}
+
+      iex> delete_cart(cart)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_cart(%Cart{} = cart) do
+    Repo.delete(cart)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking cart changes.
+
+  ## Examples
+
+      iex> change_cart(cart)
+      %Ecto.Changeset{data: %Cart{}}
+
+  """
+  def change_cart(%Cart{} = cart, attrs \\ %{}) do
+    Cart.changeset(cart, attrs)
+  end
+end

--- a/lib/eye2eye/shopping_cart.ex
+++ b/lib/eye2eye/shopping_cart.ex
@@ -101,4 +101,100 @@ defmodule Eye2eye.ShoppingCart do
   def change_cart(%Cart{} = cart, attrs \\ %{}) do
     Cart.changeset(cart, attrs)
   end
+
+  alias Eye2eye.ShoppingCart.CartItem
+
+  @doc """
+  Returns the list of cart_items.
+
+  ## Examples
+
+      iex> list_cart_items()
+      [%CartItem{}, ...]
+
+  """
+  def list_cart_items do
+    Repo.all(CartItem)
+  end
+
+  @doc """
+  Gets a single cart_item.
+
+  Raises `Ecto.NoResultsError` if the Cart item does not exist.
+
+  ## Examples
+
+      iex> get_cart_item!(123)
+      %CartItem{}
+
+      iex> get_cart_item!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_cart_item!(id), do: Repo.get!(CartItem, id)
+
+  @doc """
+  Creates a cart_item.
+
+  ## Examples
+
+      iex> create_cart_item(%{field: value})
+      {:ok, %CartItem{}}
+
+      iex> create_cart_item(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_cart_item(attrs \\ %{}) do
+    %CartItem{}
+    |> CartItem.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a cart_item.
+
+  ## Examples
+
+      iex> update_cart_item(cart_item, %{field: new_value})
+      {:ok, %CartItem{}}
+
+      iex> update_cart_item(cart_item, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_cart_item(%CartItem{} = cart_item, attrs) do
+    cart_item
+    |> CartItem.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a cart_item.
+
+  ## Examples
+
+      iex> delete_cart_item(cart_item)
+      {:ok, %CartItem{}}
+
+      iex> delete_cart_item(cart_item)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_cart_item(%CartItem{} = cart_item) do
+    Repo.delete(cart_item)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking cart_item changes.
+
+  ## Examples
+
+      iex> change_cart_item(cart_item)
+      %Ecto.Changeset{data: %CartItem{}}
+
+  """
+  def change_cart_item(%CartItem{} = cart_item, attrs \\ %{}) do
+    CartItem.changeset(cart_item, attrs)
+  end
 end

--- a/lib/eye2eye/shopping_cart/cart.ex
+++ b/lib/eye2eye/shopping_cart/cart.ex
@@ -6,6 +6,8 @@ defmodule Eye2eye.ShoppingCart.Cart do
   schema "carts" do
     field :user_uuid, Ecto.UUID
 
+    has_many :items, Eye2eye.ShoppingCart.CartItem
+
     timestamps()
   end
 

--- a/lib/eye2eye/shopping_cart/cart.ex
+++ b/lib/eye2eye/shopping_cart/cart.ex
@@ -1,0 +1,19 @@
+defmodule Eye2eye.ShoppingCart.Cart do
+  @moduledoc false
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "carts" do
+    field :user_uuid, Ecto.UUID
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(cart, attrs) do
+    cart
+    |> cast(attrs, [:user_uuid])
+    |> validate_required([:user_uuid])
+    |> unique_constraint(:user_uuid)
+  end
+end

--- a/lib/eye2eye/shopping_cart/cart_item.ex
+++ b/lib/eye2eye/shopping_cart/cart_item.ex
@@ -4,8 +4,9 @@ defmodule Eye2eye.ShoppingCart.CartItem do
 
   schema "cart_items" do
     field :quantity, :integer
-    field :cart_id, :id
-    field :product_id, :id
+
+    belongs_to :cart. Eye2eye.ShoppingCart.CartItem
+    belongs_to :product, Eye2eye.Catalog.Product
 
     timestamps()
   end

--- a/lib/eye2eye/shopping_cart/cart_item.ex
+++ b/lib/eye2eye/shopping_cart/cart_item.ex
@@ -5,7 +5,7 @@ defmodule Eye2eye.ShoppingCart.CartItem do
   schema "cart_items" do
     field :quantity, :integer
 
-    belongs_to :cart. Eye2eye.ShoppingCart.CartItem
+    belongs_to :cart, Eye2eye.ShoppingCart.CartItem
     belongs_to :product, Eye2eye.Catalog.Product
 
     timestamps()
@@ -16,5 +16,6 @@ defmodule Eye2eye.ShoppingCart.CartItem do
     cart_item
     |> cast(attrs, [:quantity])
     |> validate_required([:quantity])
+    |> validate_number(:quantity, greater_than_or_equal_to: 0, less_than: 100)
   end
 end

--- a/lib/eye2eye/shopping_cart/cart_item.ex
+++ b/lib/eye2eye/shopping_cart/cart_item.ex
@@ -1,0 +1,19 @@
+defmodule Eye2eye.ShoppingCart.CartItem do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "cart_items" do
+    field :quantity, :integer
+    field :cart_id, :id
+    field :product_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(cart_item, attrs) do
+    cart_item
+    |> cast(attrs, [:quantity])
+    |> validate_required([:quantity])
+  end
+end

--- a/lib/eye2eye/shopping_cart/cart_item.ex
+++ b/lib/eye2eye/shopping_cart/cart_item.ex
@@ -1,4 +1,5 @@
 defmodule Eye2eye.ShoppingCart.CartItem do
+  @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/priv/repo/migrations/20220830125305_create_carts.exs
+++ b/priv/repo/migrations/20220830125305_create_carts.exs
@@ -1,0 +1,13 @@
+defmodule Eye2eye.Repo.Migrations.CreateCarts do
+  use Ecto.Migration
+
+  def change do
+    create table(:carts) do
+      add :user_uuid, :uuid
+
+      timestamps()
+    end
+
+    create unique_index(:carts, [:user_uuid])
+  end
+end

--- a/priv/repo/migrations/20220830131914_create_cart_items.exs
+++ b/priv/repo/migrations/20220830131914_create_cart_items.exs
@@ -12,5 +12,6 @@ defmodule Eye2eye.Repo.Migrations.CreateCartItems do
 
     create index(:cart_items, [:cart_id])
     create index(:cart_items, [:product_id])
+    create unique_index(:cart_items, [:cart_id, :product_id])
   end
 end

--- a/priv/repo/migrations/20220830131914_create_cart_items.exs
+++ b/priv/repo/migrations/20220830131914_create_cart_items.exs
@@ -1,0 +1,16 @@
+defmodule Eye2eye.Repo.Migrations.CreateCartItems do
+  use Ecto.Migration
+
+  def change do
+    create table(:cart_items) do
+      add :quantity, :integer
+      add :cart_id, references(:carts, on_delete: :nothing)
+      add :product_id, references(:products, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:cart_items, [:cart_id])
+    create index(:cart_items, [:product_id])
+  end
+end

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -93,7 +93,16 @@ defmodule Eye2eye.ShoppingCartTest do
       assert cart_item.quantity == 43
     end
 
-    test "update_cart_item/2 with invalid data returns error changeset" do
+    test "update_cart_item/2 with invalid quantity data returns error changeset" do
+      cart_item = cart_item_fixture()
+      update_attrs = %{quantity: 101}
+
+      assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart_item(cart_item, update_attrs)
+      assert cart_item == ShoppingCart.get_cart_item!(cart_item.id)
+      assert cart_item.quantity == 42
+    end
+
+    test "update_cart_item/2 with nil quantity data returns error changeset" do
       cart_item = cart_item_fixture()
       assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart_item(cart_item, @invalid_attrs)
       assert cart_item == ShoppingCart.get_cart_item!(cart_item.id)

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -1,0 +1,59 @@
+defmodule Eye2eye.ShoppingCartTest do
+  use Eye2eye.DataCase
+
+  alias Eye2eye.ShoppingCart
+
+  describe "carts" do
+    alias Eye2eye.ShoppingCart.Cart
+
+    import Eye2eye.ShoppingCartFixtures
+
+    @invalid_attrs %{user_uuid: nil}
+
+    test "list_carts/0 returns all carts" do
+      cart = cart_fixture()
+      assert ShoppingCart.list_carts() == [cart]
+    end
+
+    test "get_cart!/1 returns the cart with given id" do
+      cart = cart_fixture()
+      assert ShoppingCart.get_cart!(cart.id) == cart
+    end
+
+    test "create_cart/1 with valid data creates a cart" do
+      valid_attrs = %{user_uuid: "7488a646-e31f-11e4-aace-600308960662"}
+
+      assert {:ok, %Cart{} = cart} = ShoppingCart.create_cart(valid_attrs)
+      assert cart.user_uuid == "7488a646-e31f-11e4-aace-600308960662"
+    end
+
+    test "create_cart/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = ShoppingCart.create_cart(@invalid_attrs)
+    end
+
+    test "update_cart/2 with valid data updates the cart" do
+      cart = cart_fixture()
+      update_attrs = %{user_uuid: "7488a646-e31f-11e4-aace-600308960668"}
+
+      assert {:ok, %Cart{} = cart} = ShoppingCart.update_cart(cart, update_attrs)
+      assert cart.user_uuid == "7488a646-e31f-11e4-aace-600308960668"
+    end
+
+    test "update_cart/2 with invalid data returns error changeset" do
+      cart = cart_fixture()
+      assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart(cart, @invalid_attrs)
+      assert cart == ShoppingCart.get_cart!(cart.id)
+    end
+
+    test "delete_cart/1 deletes the cart" do
+      cart = cart_fixture()
+      assert {:ok, %Cart{}} = ShoppingCart.delete_cart(cart)
+      assert_raise Ecto.NoResultsError, fn -> ShoppingCart.get_cart!(cart.id) end
+    end
+
+    test "change_cart/1 returns a cart changeset" do
+      cart = cart_fixture()
+      assert %Ecto.Changeset{} = ShoppingCart.change_cart(cart)
+    end
+  end
+end

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -56,4 +56,58 @@ defmodule Eye2eye.ShoppingCartTest do
       assert %Ecto.Changeset{} = ShoppingCart.change_cart(cart)
     end
   end
+
+  describe "cart_items" do
+    alias Eye2eye.ShoppingCart.CartItem
+
+    import Eye2eye.ShoppingCartFixtures
+
+    @invalid_attrs %{quantity: nil}
+
+    test "list_cart_items/0 returns all cart_items" do
+      cart_item = cart_item_fixture()
+      assert ShoppingCart.list_cart_items() == [cart_item]
+    end
+
+    test "get_cart_item!/1 returns the cart_item with given id" do
+      cart_item = cart_item_fixture()
+      assert ShoppingCart.get_cart_item!(cart_item.id) == cart_item
+    end
+
+    test "create_cart_item/1 with valid data creates a cart_item" do
+      valid_attrs = %{quantity: 42}
+
+      assert {:ok, %CartItem{} = cart_item} = ShoppingCart.create_cart_item(valid_attrs)
+      assert cart_item.quantity == 42
+    end
+
+    test "create_cart_item/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = ShoppingCart.create_cart_item(@invalid_attrs)
+    end
+
+    test "update_cart_item/2 with valid data updates the cart_item" do
+      cart_item = cart_item_fixture()
+      update_attrs = %{quantity: 43}
+
+      assert {:ok, %CartItem{} = cart_item} = ShoppingCart.update_cart_item(cart_item, update_attrs)
+      assert cart_item.quantity == 43
+    end
+
+    test "update_cart_item/2 with invalid data returns error changeset" do
+      cart_item = cart_item_fixture()
+      assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart_item(cart_item, @invalid_attrs)
+      assert cart_item == ShoppingCart.get_cart_item!(cart_item.id)
+    end
+
+    test "delete_cart_item/1 deletes the cart_item" do
+      cart_item = cart_item_fixture()
+      assert {:ok, %CartItem{}} = ShoppingCart.delete_cart_item(cart_item)
+      assert_raise Ecto.NoResultsError, fn -> ShoppingCart.get_cart_item!(cart_item.id) end
+    end
+
+    test "change_cart_item/1 returns a cart_item changeset" do
+      cart_item = cart_item_fixture()
+      assert %Ecto.Changeset{} = ShoppingCart.change_cart_item(cart_item)
+    end
+  end
 end

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -89,7 +89,9 @@ defmodule Eye2eye.ShoppingCartTest do
       cart_item = cart_item_fixture()
       update_attrs = %{quantity: 43}
 
-      assert {:ok, %CartItem{} = cart_item} = ShoppingCart.update_cart_item(cart_item, update_attrs)
+      assert {:ok, %CartItem{} = cart_item} =
+               ShoppingCart.update_cart_item(cart_item, update_attrs)
+
       assert cart_item.quantity == 43
     end
 
@@ -104,7 +106,10 @@ defmodule Eye2eye.ShoppingCartTest do
 
     test "update_cart_item/2 with nil quantity data returns error changeset" do
       cart_item = cart_item_fixture()
-      assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart_item(cart_item, @invalid_attrs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               ShoppingCart.update_cart_item(cart_item, @invalid_attrs)
+
       assert cart_item == ShoppingCart.get_cart_item!(cart_item.id)
     end
 

--- a/test/support/fixtures/shopping_cart_fixtures.ex
+++ b/test/support/fixtures/shopping_cart_fixtures.ex
@@ -1,0 +1,27 @@
+defmodule Eye2eye.ShoppingCartFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Eye2eye.ShoppingCart` context.
+  """
+
+  @doc """
+  Generate a unique cart user_uuid.
+  """
+  def unique_cart_user_uuid do
+    Ecto.UUID.generate()
+  end
+
+  @doc """
+  Generate a cart.
+  """
+  def cart_fixture(attrs \\ %{}) do
+    {:ok, cart} =
+      attrs
+      |> Enum.into(%{
+        user_uuid: unique_cart_user_uuid()
+      })
+      |> Eye2eye.ShoppingCart.create_cart()
+
+    cart
+  end
+end

--- a/test/support/fixtures/shopping_cart_fixtures.ex
+++ b/test/support/fixtures/shopping_cart_fixtures.ex
@@ -24,4 +24,18 @@ defmodule Eye2eye.ShoppingCartFixtures do
 
     cart
   end
+
+  @doc """
+  Generate a cart_item.
+  """
+  def cart_item_fixture(attrs \\ %{}) do
+    {:ok, cart_item} =
+      attrs
+      |> Enum.into(%{
+        quantity: 42
+      })
+      |> Eye2eye.ShoppingCart.create_cart_item()
+
+    cart_item
+  end
 end


### PR DESCRIPTION
This PR relates to [this ticket](https://trello.com/c/hr3PXaJh/33-add-shoppingcart-context)

The following schemas have been created in `ShoppingCart` context, who handles basic cart duties:

`Cart` resource for storing the user's cart, be tracked by an anonymous user UUID
- user_uuid:uuid:unique

`CartItem` to track products in the cart and to tie a user to their cart which holds cart items.
- quantity:integer
- cart_id:references:carts 
- product_id:references:products 
