### PR TITLE
Add shopping counter

### DIFF
--- a/lib/eye2eye/shopping_cart.ex
+++ b/lib/eye2eye/shopping_cart.ex
@@ -85,6 +85,13 @@ defmodule Eye2eye.ShoppingCart do
 
   defp reload_cart(%Cart{} = cart), do: get_cart_by_user_uuid(cart.user_uuid)
 
+  def total_cart_items(%Cart{} = cart) do
+    Enum.reduce(cart.items, 0, fn item, acc ->
+      item.quantity
+      |> Decimal.add(acc)
+    end)
+  end
+
   @doc """
   Updates a cart.
 

--- a/lib/eye2eye_web/controllers/product_controller.ex
+++ b/lib/eye2eye_web/controllers/product_controller.ex
@@ -1,11 +1,12 @@
 defmodule Eye2eyeWeb.ProductController do
   use Eye2eyeWeb, :controller
 
-  alias Eye2eye.Catalog
-  alias Eye2eye.Catalog.Product
+  alias Eye2eye.{ShoppingCart, Catalog}
 
   def index(conn, _params) do
     products = Catalog.list_products()
-    render(conn, "index.html", products: products)
+    total_cart_items = ShoppingCart.total_cart_items(conn.assigns.cart)
+
+    render(conn, "index.html", products: products, total_cart_items: total_cart_items)
   end
 end

--- a/lib/eye2eye_web/templates/layout/app.html.heex
+++ b/lib/eye2eye_web/templates/layout/app.html.heex
@@ -1,3 +1,22 @@
+<header>
+  <section class="container">
+    <nav class="gap-sm">
+      <h1 class="margin-none "><a href="/" class="font-black">eye2eye</a></h1>
+
+      <div class="font-sm row__nav ">
+        <a href="/">Your Orders</a>
+        <a href="/"> 
+          🛍️ 
+          <%= if @total_cart_items > 0 do %>
+            <span><%= @total_cart_items%></span>
+          <% end %>
+        </a>
+        <cart_counter />
+      </div>
+    </nav>
+  </section>
+</header>
+
 <main class="container">
   <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
   <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>

--- a/lib/eye2eye_web/templates/layout/root.html.heex
+++ b/lib/eye2eye_web/templates/layout/root.html.heex
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csrf-token" content={csrf_token_value()} />
-    <%= live_title_tag(assigns[:page_title] || "Eye2eye", suffix: " · Phoenix Framework") %>
+    <%= live_title_tag(assigns[:page_title] || "eye2eye", suffix: " · Phoenix Framework") %>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")} />
     <script
       defer
@@ -16,18 +16,6 @@
     </script>
   </head>
   <body>
-    <header>
-      <section class="container">
-        <nav class="gap-sm">
-          <h1 class="margin-none "><a href="/" class="font-black">eye2eye</a></h1>
-    
-          <div class="font-sm row__nav ">
-            <a href="/">Your Orders</a>
-            <a href="/"> 🛍️ </a>
-          </div>
-        </nav>
-      </section>
-    </header>
     <%= @inner_content %>
   </body>
 </html>

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -1,130 +1,127 @@
 defmodule Eye2eye.ShoppingCartTest do
   use Eye2eye.DataCase
 
-  # alias Eye2eye.ShoppingCart
+  alias Eye2eye.ShoppingCart
+  alias Eye2eye.ShoppingCart.{CartItem, Cart}
+
+  import Eye2eye.ShoppingCartFixtures
 
   describe "carts" do
-    # alias Eye2eye.ShoppingCart.Cart
+    @valid_attrs %{user_uuid: "7488a646-e31f-11e4-aace-600308960662"}
+    @invalid_attrs %{user_uuid: nil}
 
-    # import Eye2eye.ShoppingCartFixtures
-
-    # @invalid_attrs %{user_uuid: nil}
-
-    #   test "list_carts/0 returns all carts" do
-    #     cart = cart_fixture()
-    #     assert ShoppingCart.list_carts() == [cart]
-    #   end
-
-    #   test "get_cart!/1 returns the cart with given id" do
-    #     cart = cart_fixture()
-    #     assert ShoppingCart.get_cart!(cart.id) == cart
-    #   end
-
-    #   test "create_cart/1 with valid data creates a cart" do
-    #     valid_attrs = %{user_uuid: "7488a646-e31f-11e4-aace-600308960662"}
-
-    #     assert {:ok, %Cart{} = cart} = ShoppingCart.create_cart(valid_attrs)
-    #     assert cart.user_uuid == "7488a646-e31f-11e4-aace-600308960662"
-    #   end
-
-    #   test "create_cart/1 with invalid data returns error changeset" do
-    #     assert {:error, %Ecto.Changeset{}} = ShoppingCart.create_cart(@invalid_attrs)
-    #   end
-
-    #   test "update_cart/2 with valid data updates the cart" do
-    #     cart = cart_fixture()
-    #     IO.puts("TYEST 34: ")
-    #     IO.inspect(cart)
-    #     update_attrs = %{user_uuid: "7488a646-e31f-11e4-aace-600308960668"}
-
-    #     assert {:ok, %Cart{} = cart} = ShoppingCart.update_cart(cart, update_attrs)
-    #     assert cart.user_uuid == "7488a646-e31f-11e4-aace-600308960668"
-    #   end
-
-    #   test "update_cart/2 with invalid data returns error changeset" do
-    #     cart = cart_fixture()
-    #     assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart(cart, @invalid_attrs)
-    #     assert cart == ShoppingCart.get_cart!(cart.id)
-    #   end
-
-    #   test "delete_cart/1 deletes the cart" do
-    #     cart = cart_fixture()
-    #     assert {:ok, %Cart{}} = ShoppingCart.delete_cart(cart)
-    #     assert_raise Ecto.NoResultsError, fn -> ShoppingCart.get_cart!(cart.id) end
-    #   end
-
-    #   test "change_cart/1 returns a cart changeset" do
-    #     cart = cart_fixture()
-
-    #     assert %Ecto.Changeset{} = ShoppingCart.change_cart(cart)
-    #   end
+    # test "list_carts/0 returns all carts" do
+    #   cart = cart_fixture()
+    #   assert ShoppingCart.list_carts() == [cart]
     # end
 
-    # describe "cart_items" do
-    #   alias Eye2eye.ShoppingCart.CartItem
+    # test "get_cart!/1 returns the cart with given id" do
+    #   cart = cart_fixture()
+    #   assert ShoppingCart.get_cart!(cart.id) == cart
+    # end
 
-    #   import Eye2eye.ShoppingCartFixtures
+    test "create_cart/1 with valid data creates a cart" do
+      assert {:ok, %Cart{} = cart} = ShoppingCart.create_cart(@valid_attrs.user_uuid)
+      assert cart.user_uuid == "7488a646-e31f-11e4-aace-600308960662"
+    end
 
-    #   @invalid_attrs %{quantity: nil}
+    test "create_cart/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = ShoppingCart.create_cart(@invalid_attrs.user_uuid)
+    end
 
-    #   test "list_cart_items/0 returns all cart_items" do
-    #     cart_item = cart_item_fixture()
-    #     assert ShoppingCart.list_cart_items() == [cart_item]
-    #   end
+    test "total_cart_items with valid data returns integer sum of item quantities" do
+      {:ok, %Cart{} = cart} = ShoppingCart.create_cart(@valid_attrs.user_uuid)
 
-    #   test "get_cart_item!/1 returns the cart_item with given id" do
-    #     cart_item = cart_item_fixture()
-    #     assert ShoppingCart.get_cart_item!(cart_item.id) == cart_item
-    #   end
+      assert ShoppingCart.total_cart_items(cart) == 0
+    end
 
-    #   test "create_cart_item/1 with valid data creates a cart_item" do
-    #     valid_attrs = %{quantity: 42}
+    # test "update_cart/2 with valid data updates the cart" do
+    #   cart = cart_fixture()
+    #   update_attrs = %{user_uuid: "7488a646-e31f-11e4-aace-600308960668"}
 
-    #     assert {:ok, %CartItem{} = cart_item} = ShoppingCart.create_cart_item(valid_attrs)
-    #     assert cart_item.quantity == 42
-    #   end
+    #   assert {:ok, %Cart{} = cart} = ShoppingCart.update_cart(cart, update_attrs)
+    #   assert cart.user_uuid == "7488a646-e31f-11e4-aace-600308960668"
+    # end
 
-    #   test "create_cart_item/1 with invalid data returns error changeset" do
-    #     assert {:error, %Ecto.Changeset{}} = ShoppingCart.create_cart_item(@invalid_attrs)
-    #   end
+    # test "update_cart/2 with invalid data returns error changeset" do
+    #   cart = cart_fixture()
+    #   assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart(cart, @invalid_attrs)
+    #   assert cart == ShoppingCart.get_cart!(cart.id)
+    # end
 
-    #   test "update_cart_item/2 with valid data updates the cart_item" do
-    #     cart_item = cart_item_fixture()
-    #     update_attrs = %{quantity: 43}
+    # test "delete_cart/1 deletes the cart" do
+    #   cart = cart_fixture()
+    #   assert {:ok, %Cart{}} = ShoppingCart.delete_cart(cart)
+    #   assert_raise Ecto.NoResultsError, fn -> ShoppingCart.get_cart!(cart.id) end
+    # end
 
-    #     assert {:ok, %CartItem{} = cart_item} =
-    #              ShoppingCart.update_cart_item(cart_item, update_attrs)
+    # test "change_cart/1 returns a cart changeset" do
+    #   cart = cart_fixture()
+    #   assert %Ecto.Changeset{} = ShoppingCart.change_cart(cart)
+    # end
+  end
 
-    #     assert cart_item.quantity == 43
-    #   end
+  describe "cart_items" do
+    @invalid_attrs %{quantity: nil}
 
-    #   test "update_cart_item/2 with invalid quantity data returns error changeset" do
-    #     cart_item = cart_item_fixture()
-    #     update_attrs = %{quantity: 101}
+    test "list_cart_items/0 returns all cart_items" do
+      cart_item = cart_item_fixture()
+      assert ShoppingCart.list_cart_items() == [cart_item]
+    end
 
-    #     assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart_item(cart_item, update_attrs)
-    #     assert cart_item == ShoppingCart.get_cart_item!(cart_item.id)
-    #     assert cart_item.quantity == 42
-    #   end
+    test "get_cart_item!/1 returns the cart_item with given id" do
+      cart_item = cart_item_fixture()
+      assert ShoppingCart.get_cart_item!(cart_item.id) == cart_item
+    end
 
-    #   test "update_cart_item/2 with nil quantity data returns error changeset" do
-    #     cart_item = cart_item_fixture()
+    test "create_cart_item/1 with valid data creates a cart_item" do
+      valid_attrs = %{quantity: 42}
 
-    #     assert {:error, %Ecto.Changeset{}} =
-    #              ShoppingCart.update_cart_item(cart_item, @invalid_attrs)
+      assert {:ok, %CartItem{} = cart_item} = ShoppingCart.create_cart_item(valid_attrs)
+      assert cart_item.quantity == 42
+    end
 
-    #     assert cart_item == ShoppingCart.get_cart_item!(cart_item.id)
-    #   end
+    test "create_cart_item/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = ShoppingCart.create_cart_item(@invalid_attrs)
+    end
 
-    #   test "delete_cart_item/1 deletes the cart_item" do
-    #     cart_item = cart_item_fixture()
-    #     assert {:ok, %CartItem{}} = ShoppingCart.delete_cart_item(cart_item)
-    #     assert_raise Ecto.NoResultsError, fn -> ShoppingCart.get_cart_item!(cart_item.id) end
-    #   end
+    test "update_cart_item/2 with valid data updates the cart_item" do
+      cart_item = cart_item_fixture()
+      update_attrs = %{quantity: 43}
 
-    #   test "change_cart_item/1 returns a cart_item changeset" do
-    #     cart_item = cart_item_fixture()
-    #     assert %Ecto.Changeset{} = ShoppingCart.change_cart_item(cart_item)
-    #   end
+      assert {:ok, %CartItem{} = cart_item} =
+               ShoppingCart.update_cart_item(cart_item, update_attrs)
+
+      assert cart_item.quantity == 43
+    end
+
+    test "update_cart_item/2 with invalid quantity data returns error changeset" do
+      cart_item = cart_item_fixture()
+      update_attrs = %{quantity: 101}
+
+      assert {:error, %Ecto.Changeset{}} = ShoppingCart.update_cart_item(cart_item, update_attrs)
+      assert cart_item == ShoppingCart.get_cart_item!(cart_item.id)
+      assert cart_item.quantity == 42
+    end
+
+    test "update_cart_item/2 with nil quantity data returns error changeset" do
+      cart_item = cart_item_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               ShoppingCart.update_cart_item(cart_item, @invalid_attrs)
+
+      assert cart_item == ShoppingCart.get_cart_item!(cart_item.id)
+    end
+
+    test "delete_cart_item/1 deletes the cart_item" do
+      cart_item = cart_item_fixture()
+      assert {:ok, %CartItem{}} = ShoppingCart.delete_cart_item(cart_item)
+      assert_raise Ecto.NoResultsError, fn -> ShoppingCart.get_cart_item!(cart_item.id) end
+    end
+
+    test "change_cart_item/1 returns a cart_item changeset" do
+      cart_item = cart_item_fixture()
+      assert %Ecto.Changeset{} = ShoppingCart.change_cart_item(cart_item)
+    end
   end
 end

--- a/test/support/fixtures/shopping_cart_fixtures.ex
+++ b/test/support/fixtures/shopping_cart_fixtures.ex
@@ -18,11 +18,10 @@ defmodule Eye2eye.ShoppingCartFixtures do
     {:ok, cart} =
       attrs
       |> Enum.into(%{
-        user_uuid: Ecto.UUID.generate()
+        user_uuid: unique_cart_user_uuid()
       })
       |> Eye2eye.ShoppingCart.create_cart()
 
-    I0.inspect(cart)
     cart
   end
 


### PR DESCRIPTION
This PR relates to [this ticket](https://trello.com/c/a4946nv9/23-as-a-user-i-want-to-be-able-to-see-the-shopping-cart-counter-update-when-i-add-an-item-so-that-i-can-how-many-items-are-in-my-ca)

The total quantity of cart items is calculated and passed into `app.html.heex` via `ProductController` `:index` action. A conditional has been used whereby if the total quantity is more than 0 the number is displayed on the page. This is no that when the cart is empty there is no 0 showing. 