### PR TITLE
Remove cart items

### DIFF
--- a/lib/eye2eye_web/controllers/cart_controller.ex
+++ b/lib/eye2eye_web/controllers/cart_controller.ex
@@ -1,9 +1,25 @@
 defmodule Eye2eyeWeb.CartController do
   use Eye2eyeWeb, :controller
 
-  alias Eye2eye.ShoppingCart
+  alias Eye2eye.{ShoppingCart, Catalog}
 
   def show(conn, _params) do
     render(conn, "show.html")
+  end
+
+  def update(conn, %{"item_id" => item_id, "cart_item_attrs" => cart_item_attrs}) do
+    cart_item = ShoppingCart.get_cart_item!(item_id)
+    attrs = %{quantity: String.to_integer(cart_item_attrs["quantity"])}
+
+    case ShoppingCart.update_cart_item(cart_item, attrs) do
+      {:ok, cart_item} ->
+        conn
+        |> redirect(to: Routes.cart_path(conn, :show))
+
+      {:error, _changeset} ->
+        conn
+        |> put_flash(:error, "There was an error updating your cart")
+        |> redirect(to: Routes.cart_path(conn, :show))
+    end
   end
 end

--- a/lib/eye2eye_web/controllers/cart_item_controller.ex
+++ b/lib/eye2eye_web/controllers/cart_item_controller.ex
@@ -3,10 +3,11 @@ defmodule Eye2eyeWeb.CartItemController do
 
   alias Eye2eye.{ShoppingCart, Catalog}
 
-  def create(conn, %{"product_id" => product_id}) do
+  def create(conn, %{"product_id" => product_id, "cart_item_attrs" => cart_item_attrs}) do
     product = Catalog.get_product!(product_id)
+    attrs = %{quantity: String.to_integer(cart_item_attrs["quantity"])}
 
-    case ShoppingCart.add_item_to_cart(conn.assigns.cart, product) do
+    case ShoppingCart.add_item_to_cart(conn.assigns.cart, product, attrs) do
       {:ok, _item} ->
         conn
         |> put_flash(:info, "Item added to your cart")

--- a/lib/eye2eye_web/router.ex
+++ b/lib/eye2eye_web/router.ex
@@ -47,6 +47,7 @@ defmodule Eye2eyeWeb.Router do
     resources "/cart_items", CartItemController, only: [:create]
 
     get "/cart", CartController, :show
+    put "/cart", CartController, :update
   end
 
   # Other scopes may use custom stacks.

--- a/lib/eye2eye_web/templates/cart/show.html.heex
+++ b/lib/eye2eye_web/templates/cart/show.html.heex
@@ -2,7 +2,7 @@
               <span>(<%= ShoppingCart.total_cart_items(@cart)%>)</span>
             <% end %> </h1>
 <%= if @cart.items == [] do %>
-  <h2>Your cart is empty</h2>
+  <p>Your cart is empty</p>
 <% else %>
   <ul class="list-style_none">
     <%= for item <- @cart.items do %>
@@ -11,13 +11,16 @@
         <div> 
           <p><strong><%= item.product.name %></strong></p>
           <p class="font-sm">Price: £<%= item.product.price %></p>
-          <p class="font-sm"> <em>Quantity: </em><%= item.quantity %></p>
+          <p class="font-sm"> <em>Quantity: </em><%= item.quantity%></p>
         </div>
         <div >
           <p class="margin-bottom_md">
             <b>£<%= ShoppingCart.total_item_price(item) %></b>
           </p> 
-          <p>Remove</p>
+          <%# <p>Remove</p> %>
+          <div class="btn"> 
+            <%= link "Remove", to: Routes.cart_path(@conn, :update, item_id: item.id, cart_item_attrs: %{quantity: item.quantity}), method: :put, class: "cart-btn"%> 
+          </div>
         </div>
       </li>
     <% end %>

--- a/lib/eye2eye_web/templates/product/index.html.heex
+++ b/lib/eye2eye_web/templates/product/index.html.heex
@@ -12,7 +12,7 @@
          <div class="gap-sm">
             <p>£<%= product.price %></p>
             <div class="btn"> 
-               <%= link "Add to cart", to: Routes.cart_item_path(@conn, :create, product_id: product.id), method: :post, class: "cart-btn"%> 
+               <%= link "Add to cart", to: Routes.cart_item_path(@conn, :create, product_id: product.id, cart_item_attrs: %{quantity: 1}), method: :post, class: "cart-btn"%> 
             </div>
          </div>
       </article>

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -8,6 +8,8 @@ defmodule Eye2eye.ShoppingCartTest do
   import Eye2eye.ShoppingCartFixtures
   import Eye2eye.CatalogFixtures
 
+  @valid_cart_item_attrs %{quantity: 1}
+
   describe "carts" do
     @valid_attrs %{user_uuid: "7488a646-e31f-11e4-aace-600308960662"}
     @invalid_attrs %{user_uuid: nil}
@@ -41,7 +43,6 @@ defmodule Eye2eye.ShoppingCartTest do
     test "total_cart_items when one cart item returns valid integer" do
       product = create_product_fixture()
       cart = create_cart_fixture()
-
       cart_with_one_item = add_cart_item_fixture(cart, product)
 
       assert ShoppingCart.total_cart_items(cart_with_one_item) == 1
@@ -50,7 +51,6 @@ defmodule Eye2eye.ShoppingCartTest do
     test "total_cart_items when one cart item with quantity two returns valid integer" do
       product_one = create_product_fixture()
       cart = create_cart_fixture()
-
       cart_with_item_q1 = add_cart_item_fixture(cart, product_one)
       cart_with_item_q2 = add_cart_item_fixture(cart_with_item_q1, product_one)
 
@@ -97,13 +97,30 @@ defmodule Eye2eye.ShoppingCartTest do
   end
 
   describe "cart_items" do
+    @invalid_cart_item_attrs %{quantity: 0}
+
+    test "get_cart_item!/1 returns the cart_item with given id" do
+      cart = create_cart_fixture()
+      product = create_product_fixture()
+
+      cart_with_item = add_cart_item_fixture(cart, product)
+      cart_item = hd(cart_with_item.items)
+
+      assert ShoppingCart.get_cart_item!(cart_item.id) == cart_item
+    end
+
     test "add_item_to_cart when cart is empty returns updated cart" do
       cart = create_cart_fixture()
       product = create_product_fixture()
 
       assert cart.items == []
-      assert {:ok, %Cart{} = cart} = ShoppingCart.add_item_to_cart(cart, product)
-      assert length(cart.items) == 1
+
+      assert {:ok, %CartItem{} = cart_item} =
+               ShoppingCart.add_item_to_cart(cart, product, @valid_cart_item_attrs)
+
+      reload_cart = ShoppingCart.reload_cart(cart)
+
+      assert length(reload_cart.items) == 1
     end
 
     test "add_item_to_cart when cart already has one item returns updated cart" do
@@ -112,9 +129,22 @@ defmodule Eye2eye.ShoppingCartTest do
       product_two = create_product_fixture(@product_two_attrs)
 
       assert cart.items == []
-      assert {:ok, %Cart{} = cart} = ShoppingCart.add_item_to_cart(cart, product_one)
-      assert {:ok, %Cart{} = cart} = ShoppingCart.add_item_to_cart(cart, product_two)
-      assert length(cart.items) == 2
+
+      assert {:ok, %CartItem{} = cart_item} =
+               ShoppingCart.add_item_to_cart(cart, product_one, @valid_cart_item_attrs)
+
+      cart_with_item_one = ShoppingCart.reload_cart(cart)
+
+      assert {:ok, %CartItem{} = cart} =
+               ShoppingCart.add_item_to_cart(
+                 cart_with_item_one,
+                 product_two,
+                 @valid_cart_item_attrs
+               )
+
+      cart_with_item_two = ShoppingCart.reload_cart(cart_with_item_one)
+
+      assert length(cart_with_item_two.items) == 2
     end
 
     test "add_item_to_cart when cart has the item already returns no increase in length" do
@@ -123,9 +153,22 @@ defmodule Eye2eye.ShoppingCartTest do
       product_one = create_product_fixture()
 
       assert cart.items == []
-      assert {:ok, %Cart{} = cart} = ShoppingCart.add_item_to_cart(cart, product_one)
-      assert {:ok, %Cart{} = cart} = ShoppingCart.add_item_to_cart(cart, product_one)
-      assert length(cart.items) == 1
+
+      assert {:ok, %CartItem{} = cart_item_one} =
+               ShoppingCart.add_item_to_cart(cart, product_one, @valid_cart_item_attrs)
+
+      cart_with_item_q1 = ShoppingCart.reload_cart(cart)
+
+      assert {:ok, %CartItem{} = cart_item_two} =
+               ShoppingCart.add_item_to_cart(
+                 cart_with_item_q1,
+                 product_one,
+                 @valid_cart_item_attrs
+               )
+
+      cart_with_item_q2 = ShoppingCart.reload_cart(cart_with_item_q1)
+
+      assert length(cart_with_item_q2.items) == 1
     end
 
     test "total_item_price where one cart item present with quantity one returns valid decimal" do
@@ -151,6 +194,80 @@ defmodule Eye2eye.ShoppingCartTest do
       assert cart_item.product.price === Decimal.new("120.50")
       assert cart_item.quantity === 2
       assert ShoppingCart.total_item_price(cart_item) === Decimal.new("241.00")
+    end
+
+    test "update_cart_item where one item with one quantity returns updated cart without item" do
+      product = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item = add_cart_item_fixture(cart, product)
+      cart_item = List.first(cart_with_one_item.items)
+      cart_item_attrs = %{quantity: cart_item.quantity}
+
+      assert length(cart_with_one_item.items) == 1
+      assert cart_item.quantity == 1
+
+      assert {:ok, %CartItem{} = updated_cart_item} =
+               ShoppingCart.update_cart_item(cart_item, cart_item_attrs)
+
+      assert updated_cart_item.quantity == 0
+
+      updated_cart = ShoppingCart.reload_cart(cart_with_one_item)
+      assert Enum.empty?(updated_cart.items)
+    end
+
+    test "update_cart_item where one item with two quantity returns updated cart quantity" do
+      product = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item = add_cart_item_fixture(cart, product)
+      cart_item = List.first(cart_with_one_item.items)
+
+      product_one = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item_q1 = add_cart_item_fixture(cart, product_one)
+      cart_with_one_item_q2 = add_cart_item_fixture(cart, product_one)
+      cart_item = List.first(cart_with_one_item_q2.items)
+      cart_item_attrs = %{quantity: cart_item.quantity}
+
+      assert cart_item.quantity == 2
+
+      assert {:ok, %CartItem{} = updated_cart_item} =
+               ShoppingCart.update_cart_item(cart_item, cart_item_attrs)
+
+      assert updated_cart_item.quantity == 1
+    end
+
+    test "update_cart_item with invalid cart item quantity data returns error changeset" do
+      product = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item = add_cart_item_fixture(cart, product)
+      cart_item = List.first(cart_with_one_item.items)
+
+      assert {:error, %Ecto.Changeset{}} =
+               ShoppingCart.update_cart_item(cart_item, @invalid_cart_item_attrs)
+
+      assert cart_item.quantity == 1
+    end
+
+    test "reduce_item_quantity_by_one where quantity is one returns correct integer" do
+      product = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item = add_cart_item_fixture(cart, product)
+      cart_item = List.first(cart_with_one_item.items)
+
+      assert cart_item.quantity == 1
+      assert ShoppingCart.reduce_item_quantity_by_one(cart_item).quantity == 0
+      assert Map.has_key?(ShoppingCart.reduce_item_quantity_by_one(cart_item), :quantity)
+    end
+
+    test "reduce_item_quantity_by_one where quantity is two returns correct integer" do
+      product_one = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item_q1 = add_cart_item_fixture(cart, product_one)
+      cart_with_one_item_q2 = add_cart_item_fixture(cart, product_one)
+      cart_item = List.first(cart_with_one_item_q2.items)
+
+      assert cart_item.quantity == 2
+      assert ShoppingCart.reduce_item_quantity_by_one(cart_item).quantity == 1
     end
   end
 end

--- a/test/eye2eye_web/controllers/cart_controller_test.exs
+++ b/test/eye2eye_web/controllers/cart_controller_test.exs
@@ -5,6 +5,9 @@ defmodule Eye2eyeWeb.CartControllerTest do
   alias Eye2eye.{ShoppingCart, Catalog}
 
   import Eye2eye.CatalogFixtures
+  import Eye2eye.ShoppingCartFixtures
+
+  @valid_cart_item_attrs %{quantity: 1}
 
   describe "show" do
     test "display message when cart empty", %{conn: conn} do
@@ -15,18 +18,107 @@ defmodule Eye2eyeWeb.CartControllerTest do
 
     test "display cart item when there is an item in the cart", %{conn: conn} do
       product = create_product_fixture()
-
       conn = get(conn, Routes.product_path(conn, :index))
 
-      {:ok, add_to_cart} = ShoppingCart.add_item_to_cart(conn.assigns.cart, product)
-      conn = assign(conn, :cart, add_to_cart)
+      {:ok, cart_item} =
+        ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
 
       conn = get(conn, Routes.cart_path(conn, :show))
-      conn = assign(conn, :cart, add_to_cart)
 
       assert html_response(conn, 200) =~ "Product One"
       assert html_response(conn, 200) =~ "https://images.com/1"
       assert html_response(conn, 200) =~ "120.50"
+    end
+  end
+
+  describe "update" do
+    @invalid_cart_item_attrs %{quantity: 0}
+
+    test "when item quantity one, display empty cart message when item quantity removed", %{
+      conn: conn
+    } do
+      product = create_product_fixture()
+      conn = get(conn, Routes.product_path(conn, :index))
+
+      {:ok, cart_item} =
+        ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
+
+      conn = get(conn, Routes.cart_path(conn, :show))
+      cart_item_attrs = %{quantity: cart_item.quantity}
+
+      assert html_response(conn, 200) =~ "Product One"
+      assert html_response(conn, 200) =~ "https://images.com/1"
+      assert html_response(conn, 200) =~ "120.50"
+
+      conn =
+        put(
+          conn,
+          Routes.cart_path(conn, :update, item_id: cart_item.id, cart_item_attrs: cart_item_attrs)
+        )
+
+      assert redirected_to(conn) == Routes.cart_path(conn, :show)
+
+      conn = get(conn, Routes.cart_path(conn, :show))
+
+      assert html_response(conn, 200) =~ "Your cart is empty"
+      assert html_response(conn, 200) != "Product One"
+      assert conn.assigns.cart.items == []
+    end
+
+    test "renders errors when cart item data is invalid", %{conn: conn} do
+      product = create_product_fixture()
+      conn = get(conn, Routes.product_path(conn, :index))
+
+      {:ok, cart_item} =
+        ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
+
+      conn = get(conn, Routes.cart_path(conn, :show))
+
+      conn =
+        put(
+          conn,
+          Routes.cart_path(conn, :update,
+            item_id: cart_item.id,
+            cart_item_attrs: @invalid_cart_item_attrs
+          )
+        )
+
+      assert redirected_to(conn) == Routes.cart_path(conn, :show)
+      conn = get(conn, Routes.cart_path(conn, :show))
+      assert html_response(conn, 200) =~ "There was an error updating your cart"
+    end
+
+    test "when item quantity two display updates when a cart item quantity removed", %{conn: conn} do
+      product = create_product_fixture()
+      conn = get(conn, Routes.product_path(conn, :index))
+
+      {:ok, cart_item_q1} =
+        ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
+
+      {:ok, cart_item_q2} =
+        ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
+
+      conn = get(conn, Routes.cart_path(conn, :show))
+      cart_item = List.first(conn.assigns.cart.items)
+      cart_item_attrs = %{quantity: cart_item.quantity}
+      assert cart_item.quantity == 2
+
+      conn =
+        put(
+          conn,
+          Routes.cart_path(conn, :update,
+            item_id: cart_item_q2.id,
+            cart_item_attrs: cart_item_attrs
+          )
+        )
+
+      assert redirected_to(conn) == Routes.cart_path(conn, :show)
+
+      conn = get(conn, Routes.cart_path(conn, :show))
+
+      assert length(conn.assigns.cart.items) == 1
+      assert List.first(conn.assigns.cart.items).quantity == 1
+      assert html_response(conn, 200) =~ "Product One"
     end
   end
 end

--- a/test/eye2eye_web/controllers/cart_item_controller_test.exs
+++ b/test/eye2eye_web/controllers/cart_item_controller_test.exs
@@ -6,21 +6,48 @@ defmodule Eye2eyeWeb.CartItemControllerTest do
 
   import Eye2eye.CatalogFixtures
 
-  @invalid_attrs %{product_id: 2}
+  @invalid_cart_item_attrs %{quantity: 150}
+  @valid_cart_item_attrs %{quantity: 1}
 
   describe "create a cart item" do
-    test "redirects to product index route when data is valid, displays success message and cart counter",
+    test "redirects to product index route when cart item data is valid with success message",
          %{conn: conn} do
       product = create_product_fixture()
 
-      conn = post(conn, Routes.cart_item_path(conn, :create), product_id: product.id)
+      conn =
+        post(
+          conn,
+          Routes.cart_item_path(conn, :create,
+            product_id: product.id,
+            cart_item_attrs: @valid_cart_item_attrs
+          )
+        )
 
       assert redirected_to(conn) == Routes.product_path(conn, :index)
 
       conn = get(conn, Routes.product_path(conn, :index))
 
       assert html_response(conn, 200) =~ "Item added to your cart"
-      assert ShoppingCart.total_cart_items(conn.assigns.cart) == 1
+      assert length(conn.assigns.cart.items) == 1
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      product = create_product_fixture()
+
+      conn =
+        post(
+          conn,
+          Routes.cart_item_path(conn, :create,
+            product_id: product.id,
+            cart_item_attrs: @invalid_cart_item_attrs
+          )
+        )
+
+      assert redirected_to(conn) == Routes.product_path(conn, :index)
+
+      conn = get(conn, Routes.product_path(conn, :index))
+
+      assert html_response(conn, 200) =~ "There was an error adding the item to your cart"
     end
   end
 end

--- a/test/support/fixtures/shopping_cart_fixtures.ex
+++ b/test/support/fixtures/shopping_cart_fixtures.ex
@@ -2,8 +2,10 @@ defmodule Eye2eye.ShoppingCartFixtures do
   @moduledoc """
   This module defines test helpers for creating
   entities via the `Eye2eye.ShoppingCart` context.
+  """
+  @valid_cart_item_attrs %{quantity: 1}
 
-  @doc \"""
+  @doc """
   Generate a unique cart user_uuid.
   """
   def unique_cart_user_uuid do
@@ -19,14 +21,9 @@ defmodule Eye2eye.ShoppingCartFixtures do
     cart
   end
 
-  def add_cart_item_fixture(cart, product) do
-    {:ok, cart_with_item} = Eye2eye.ShoppingCart.add_item_to_cart(cart, product)
-    cart_with_item
-  end
-
-  def reload_cart_fixture(user_uuid) do
-    {:ok, reload_cart} = Eye2eye.ShoppingCart.get_cart_by_user_uuid(user_uuid)
-
+  def add_cart_item_fixture(cart, product, attrs \\ @valid_cart_item_attrs) do
+    {:ok, cart_with_item} = Eye2eye.ShoppingCart.add_item_to_cart(cart, product, attrs)
+    {:ok, reload_cart = Eye2eye.ShoppingCart.reload_cart(cart)}
     reload_cart
   end
 end


### PR DESCRIPTION
This PR relates to the [remove cart item from shopping cart ticket](https://trello.com/c/AhHfrcLX/26-as-a-user-i-want-to-be-able-to-review-my-ordershopping-cart-so-that-i-can-remove-items-i-no-longer-want-to-buy)

- The 'remove' link triggers a put request to '/cart' with `item_id` and `cart_item_attrs` which contains the item to be removed `item.quantity`. 
- These are used to get the CartItem via `ShoppingCart.get_cart_item!` and create the quantity data map which is to be updated by the `ShoppingCart.update_cart_item` method. 
- It passes in the current quantity to a helper function `reduce_item_quantity_by_one` and then passed in the updated quantity to be validated by `CartItem.changeset`. 
- Then we utilise `Ecto.Multi()` to trigger two database calls, whereby 
   - if one fails it rollbacks the changes and CartController redirects to the shopping cart with flash message "There was an error updating your cart"
   - if successful, it first updates the cart item quantity, then where quantity is 0 it deletes the entire cart item and redirects to the shopping cart page `/cart`
 
