### PR TITLE
Add checkout

### DIFF
--- a/lib/eye2eye/orders.ex
+++ b/lib/eye2eye/orders.ex
@@ -35,9 +35,6 @@ defmodule Eye2eye.Orders do
   """
 
   def complete_order(%ShoppingCart.Cart{} = cart, order_attrs) do
-    IO.puts("CART id: "<> inspect(cart.id))
-    IO.puts("CART items cart_id: "<> inspect(List.first(cart.items).cart_id))
-
     line_items =
       Enum.map(cart.items, fn item ->
         %{product_id: item.product_id, price: item.product.price, quantity: item.quantity}

--- a/lib/eye2eye/orders.ex
+++ b/lib/eye2eye/orders.ex
@@ -1,0 +1,57 @@
+defmodule Eye2eye.Orders do
+  @moduledoc """
+  The Orders context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Eye2eye.Repo
+
+  alias Eye2eye.Orders.Order
+
+  @doc """
+  Returns the list of orders.
+
+  ## Examples
+
+      iex> list_orders()
+      [%Order{}, ...]
+
+  """
+  def list_orders do
+    Repo.all(Order)
+  end
+
+  @doc """
+  Gets a single order.
+
+  Raises `Ecto.NoResultsError` if the Order does not exist.
+
+  ## Examples
+
+      iex> get_order!(123)
+      %Order{}
+
+      iex> get_order!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_order!(id), do: Repo.get!(Order, id)
+
+  @doc """
+  Creates a order.
+
+  ## Examples
+
+      iex> create_order(%{field: value})
+      {:ok, %Order{}}
+
+      iex> create_order(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_order(attrs \\ %{}) do
+    %Order{}
+    |> Order.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/eye2eye/orders.ex
+++ b/lib/eye2eye/orders.ex
@@ -6,40 +6,23 @@ defmodule Eye2eye.Orders do
   import Ecto.Query, warn: false
 
   alias Eye2eye.Repo
+  alias Eye2eye.ShoppingCart
   alias Eye2eye.Orders.Order
   alias Eye2eye.Orders.LineItem
 
   @doc """
-  Returns the list of orders.
-
-  ## Examples
-
-      iex> list_orders()
-      [%Order{}, ...]
-
-  """
-  def list_orders do
-    Repo.all(Order)
-  end
-
-  @doc """
-  Gets a single order.
-
-  Raises `Ecto.NoResultsError` if the Order does not exist.
-
-  ## Examples
-
-      iex> get_order!(123)
-      %Order{}
-
-      iex> get_order!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_order!(id), do: Repo.get!(Order, id)
-
-  @doc """
   Creates a order.
+
+  First by mapping the cart items of the shopping
+  cart passed into a map of order line items structs
+  which captures the product id, price and quantity.
+
+  Then create an order changeset by passing in an empty
+  Order changeset and our changes
+  (user_uuid, total_price, line_items).
+
+  Next the order is inserted and the run operation to
+  prune the shopping cart
 
   ## Examples
 
@@ -50,56 +33,24 @@ defmodule Eye2eye.Orders do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_order(attrs \\ %{}) do
+
+  def complete_order(%ShoppingCart.Cart{} = cart, order_attrs) do
+    line_items =
+      Enum.map(cart.items, fn item ->
+        %{product_id: item.product_id, price: item.product.price, quantity: item.quantity}
+      end)
+      
+    order_changeset =
     %Order{}
-    |> Order.changeset(attrs)
-    |> Repo.insert()
-  end
+    |> Order.changeset(order_attrs)
+    |> Ecto.Changeset.change(line_items: line_items)
 
-  @doc """
-  Returns the list of order_line_items.
-
-  ## Examples
-
-      iex> list_order_line_items()
-      [%LineItem{}, ...]
-
-  """
-  def list_order_line_items do
-    Repo.all(LineItem)
-  end
-
-  @doc """
-  Gets a single line_item.
-
-  Raises `Ecto.NoResultsError` if the Line item does not exist.
-
-  ## Examples
-
-      iex> get_line_item!(123)
-      %LineItem{}
-
-      iex> get_line_item!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_line_item!(id), do: Repo.get!(LineItem, id)
-
-  @doc """
-  Creates a line_item.
-
-  ## Examples
-
-      iex> create_line_item(%{field: value})
-      {:ok, %LineItem{}}
-
-      iex> create_line_item(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def create_line_item(attrs \\ %{}) do
-    %LineItem{}
-    |> LineItem.changeset(attrs)
-    |> Repo.insert()
+    Ecto.Multi.new()
+    |> Ecto.Multi.insert(:order, order_changeset)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{order: order}} -> {:ok, order}
+      {:error, :order, changeset, _changes_so_far} -> {:error, changeset}
+    end
   end
 end

--- a/lib/eye2eye/orders.ex
+++ b/lib/eye2eye/orders.ex
@@ -4,9 +4,10 @@ defmodule Eye2eye.Orders do
   """
 
   import Ecto.Query, warn: false
-  alias Eye2eye.Repo
 
+  alias Eye2eye.Repo
   alias Eye2eye.Orders.Order
+  alias Eye2eye.Orders.LineItem
 
   @doc """
   Returns the list of orders.
@@ -52,6 +53,53 @@ defmodule Eye2eye.Orders do
   def create_order(attrs \\ %{}) do
     %Order{}
     |> Order.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Returns the list of order_line_items.
+
+  ## Examples
+
+      iex> list_order_line_items()
+      [%LineItem{}, ...]
+
+  """
+  def list_order_line_items do
+    Repo.all(LineItem)
+  end
+
+  @doc """
+  Gets a single line_item.
+
+  Raises `Ecto.NoResultsError` if the Line item does not exist.
+
+  ## Examples
+
+      iex> get_line_item!(123)
+      %LineItem{}
+
+      iex> get_line_item!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_line_item!(id), do: Repo.get!(LineItem, id)
+
+  @doc """
+  Creates a line_item.
+
+  ## Examples
+
+      iex> create_line_item(%{field: value})
+      {:ok, %LineItem{}}
+
+      iex> create_line_item(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_line_item(attrs \\ %{}) do
+    %LineItem{}
+    |> LineItem.changeset(attrs)
     |> Repo.insert()
   end
 end

--- a/lib/eye2eye/orders/line_item.ex
+++ b/lib/eye2eye/orders/line_item.ex
@@ -5,8 +5,9 @@ defmodule Eye2eye.Orders.LineItem do
   schema "order_line_items" do
     field :price, :decimal
     field :quantity, :integer
-    field :order_id, :id
-    field :product_id, :id
+
+    belongs_to :order, Eye2eye.Orders.Order
+    belongs_to :product, Eye2eye.Catalog.Product
 
     timestamps()
   end

--- a/lib/eye2eye/orders/line_item.ex
+++ b/lib/eye2eye/orders/line_item.ex
@@ -1,4 +1,5 @@
 defmodule Eye2eye.Orders.LineItem do
+  @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/eye2eye/orders/line_item.ex
+++ b/lib/eye2eye/orders/line_item.ex
@@ -1,0 +1,20 @@
+defmodule Eye2eye.Orders.LineItem do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "order_line_items" do
+    field :price, :decimal
+    field :quantity, :integer
+    field :order_id, :id
+    field :product_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(line_item, attrs) do
+    line_item
+    |> cast(attrs, [:price, :quantity])
+    |> validate_required([:price, :quantity])
+  end
+end

--- a/lib/eye2eye/orders/order.ex
+++ b/lib/eye2eye/orders/order.ex
@@ -1,0 +1,18 @@
+defmodule Eye2eye.Orders.Order do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "orders" do
+    field :total_price, :decimal
+    field :user_uuid, Ecto.UUID
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(order, attrs) do
+    order
+    |> cast(attrs, [:user_uuid, :total_price])
+    |> validate_required([:user_uuid, :total_price])
+  end
+end

--- a/lib/eye2eye/orders/order.ex
+++ b/lib/eye2eye/orders/order.ex
@@ -6,6 +6,9 @@ defmodule Eye2eye.Orders.Order do
     field :total_price, :decimal
     field :user_uuid, Ecto.UUID
 
+    has_many :line_items, Eye2eye.Orders.LineItem
+    has_many :products, through: [:line_items, :product]
+
     timestamps()
   end
 

--- a/lib/eye2eye/orders/order.ex
+++ b/lib/eye2eye/orders/order.ex
@@ -1,4 +1,5 @@
 defmodule Eye2eye.Orders.Order do
+  @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/eye2eye/shopping_cart.ex
+++ b/lib/eye2eye/shopping_cart.ex
@@ -56,13 +56,28 @@ defmodule Eye2eye.ShoppingCart do
     end
   end
 
+  @doc """
+  Reloads the cart by get_cart_by_user_uuid
+
+  """
+
   def reload_cart(%Cart{} = cart), do: get_cart_by_user_uuid(cart.user_uuid)
+
+  @doc """
+  Calculates the total cart items by adding together all cart_item.quantity
+
+  """
 
   def total_cart_items(%Cart{} = cart) do
     Enum.reduce(cart.items, 0, fn item, acc ->
       item.quantity + acc
     end)
   end
+
+  @doc """
+    Calculates the total cart price by adding together cart item totals
+
+  """
 
   def total_cart_price(%Cart{} = cart) do
     Enum.reduce(cart.items, @min_cart_item_price, fn item, acc ->
@@ -71,8 +86,6 @@ defmodule Eye2eye.ShoppingCart do
       |> Decimal.add(acc)
     end)
   end
-
-  # ----- CART ITEMS FUNCTIONS START HERE -----
 
   @doc """
   Gets a single cart_item by id and add product
@@ -156,10 +169,24 @@ defmodule Eye2eye.ShoppingCart do
     end
   end
 
+  @doc """
+  Reduces cart item quantity by one
+
+  """
+
   def reduce_item_quantity_by_one(cart_item_attrs, updated_attrs \\ %{}) do
     updated_quantity = cart_item_attrs.quantity - 1
 
     updated_attrs
     |> Enum.into(%{quantity: updated_quantity})
+  end
+
+  @doc """
+  Deletes cart items for a given cart_id
+
+  """
+  def prune_cart_items(%Cart{} = cart) do
+    {_, _} = Repo.delete_all(from(i in CartItem, where: i.cart_id == ^cart.id))
+    {:ok, reload_cart(cart)}
   end
 end

--- a/lib/eye2eye_web/controllers/order_controller.ex
+++ b/lib/eye2eye_web/controllers/order_controller.ex
@@ -5,13 +5,8 @@ defmodule Eye2eyeWeb.OrderController do
   alias Eye2eye.Orders.Order
   alias Eye2eye.{ShoppingCart, Catalog}
 
-  def create(conn, %{"order_attrs" => order_attrs}) do
-    attrs = %{
-      user_uuid: order_attrs["user_uuid"],
-      total_price: order_attrs["total_price"]
-    }
-
-    case Orders.complete_order(conn.assigns.cart, order_attrs) do
+  def create(conn, %{"order" => order_params}) do
+    case Orders.complete_order(conn.assigns.cart, order_params) do
       {:ok, order} ->
         conn
         |> put_flash(:info, "Order created successfully.")

--- a/lib/eye2eye_web/controllers/order_controller.ex
+++ b/lib/eye2eye_web/controllers/order_controller.ex
@@ -5,16 +5,11 @@ defmodule Eye2eyeWeb.OrderController do
   alias Eye2eye.Orders.Order
   alias Eye2eye.{ShoppingCart, Catalog}
 
-  def create(conn, %{"order_attrs"=> order_attrs}) do
-    IO.puts("CREATE order_attrs "<> inspect(order_attrs))
-
+  def create(conn, %{"order_attrs" => order_attrs}) do
     attrs = %{
       user_uuid: order_attrs["user_uuid"],
       total_price: order_attrs["total_price"]
     }
-
-    IO.puts("CREATE attrs "<> inspect(order_attrs))
-    IO.puts("CREATE CART assigns "<> inspect(conn.assigns.cart))
 
     case Orders.complete_order(conn.assigns.cart, order_attrs) do
       {:ok, order} ->
@@ -22,10 +17,10 @@ defmodule Eye2eyeWeb.OrderController do
         |> put_flash(:info, "Order created successfully.")
         |> redirect(to: Routes.cart_path(conn, :show))
 
-        {:error, _changeset} ->
-          conn
-          |> put_flash(:error, "There was an error updating your cart")
-          |> redirect(to: Routes.cart_path(conn, :show))
+      {:error, _changeset} ->
+        conn
+        |> put_flash(:error, "There was an error updating your cart")
+        |> redirect(to: Routes.cart_path(conn, :show))
     end
   end
 end

--- a/lib/eye2eye_web/controllers/order_controller.ex
+++ b/lib/eye2eye_web/controllers/order_controller.ex
@@ -1,0 +1,31 @@
+defmodule Eye2eyeWeb.OrderController do
+  use Eye2eyeWeb, :controller
+
+  alias Eye2eye.Orders
+  alias Eye2eye.Orders.Order
+  alias Eye2eye.{ShoppingCart, Catalog}
+
+  def create(conn, %{"order_attrs"=> order_attrs}) do
+    IO.puts("CREATE order_attrs "<> inspect(order_attrs))
+
+    attrs = %{
+      user_uuid: order_attrs["user_uuid"],
+      total_price: order_attrs["total_price"]
+    }
+
+    IO.puts("CREATE attrs "<> inspect(order_attrs))
+    IO.puts("CREATE CART assigns "<> inspect(conn.assigns.cart))
+
+    case Orders.complete_order(conn.assigns.cart, order_attrs) do
+      {:ok, order} ->
+        conn
+        |> put_flash(:info, "Order created successfully.")
+        |> redirect(to: Routes.cart_path(conn, :show))
+
+        {:error, _changeset} ->
+          conn
+          |> put_flash(:error, "There was an error updating your cart")
+          |> redirect(to: Routes.cart_path(conn, :show))
+    end
+  end
+end

--- a/lib/eye2eye_web/router.ex
+++ b/lib/eye2eye_web/router.ex
@@ -48,6 +48,8 @@ defmodule Eye2eyeWeb.Router do
 
     get "/cart", CartController, :show
     put "/cart", CartController, :update
+
+    resources "/orders", OrderController, only: [:create]
   end
 
   # Other scopes may use custom stacks.

--- a/lib/eye2eye_web/templates/cart/show.html.heex
+++ b/lib/eye2eye_web/templates/cart/show.html.heex
@@ -27,8 +27,8 @@
   </ul>
   <div class="checkout-container">
     <p><b>Total</b>: £<%= ShoppingCart.total_cart_price(@cart) %></p>
-    <div class="btn cart-btn"> 
-      <p>Checkout </p>
+    <div class="btn"> 
+      <%= link "Checkout", to: Routes.order_path(@conn, :create), method: :post, class: "cart-btn"%>
     </div>
   </div>
 <% end %>

--- a/lib/eye2eye_web/templates/cart/show.html.heex
+++ b/lib/eye2eye_web/templates/cart/show.html.heex
@@ -17,7 +17,6 @@
           <p class="margin-bottom_md">
             <b>£<%= ShoppingCart.total_item_price(item) %></b>
           </p> 
-          <%# <p>Remove</p> %>
           <div class="btn"> 
             <%= link "Remove", to: Routes.cart_path(@conn, :update, item_id: item.id, cart_item_attrs: %{quantity: item.quantity}), method: :put, class: "cart-btn"%> 
           </div>
@@ -28,7 +27,8 @@
   <div class="checkout-container">
     <p><b>Total</b>: £<%= ShoppingCart.total_cart_price(@cart) %></p>
     <div class="btn"> 
-      <%= link "Checkout", to: Routes.order_path(@conn, :create), method: :post, class: "cart-btn"%>
+      <%= link "Checkout", to: Routes.order_path(@conn, :create, order_attrs: %{user_uuid: @cart.user_uuid, total_price: Decimal.to_string(ShoppingCart.total_cart_price(@cart))}), 
+       method: :post, class: "cart-btn"%>
     </div>
   </div>
 <% end %>

--- a/lib/eye2eye_web/templates/cart/show.html.heex
+++ b/lib/eye2eye_web/templates/cart/show.html.heex
@@ -27,7 +27,7 @@
   <div class="checkout-container">
     <p><b>Total</b>: £<%= ShoppingCart.total_cart_price(@cart) %></p>
     <div class="btn"> 
-      <%= link "Checkout", to: Routes.order_path(@conn, :create, order_attrs: %{user_uuid: @cart.user_uuid, total_price: Decimal.to_string(ShoppingCart.total_cart_price(@cart))}), 
+      <%= link "Checkout", to: Routes.order_path(@conn, :create, order: %{user_uuid: @cart.user_uuid, total_price: Decimal.to_string(ShoppingCart.total_cart_price(@cart))}), 
        method: :post, class: "cart-btn"%>
     </div>
   </div>

--- a/lib/eye2eye_web/views/order_view.ex
+++ b/lib/eye2eye_web/views/order_view.ex
@@ -1,0 +1,3 @@
+defmodule Eye2eyeWeb.OrderView do
+  use Eye2eyeWeb, :view
+end

--- a/priv/repo/migrations/20220907105410_create_orders.exs
+++ b/priv/repo/migrations/20220907105410_create_orders.exs
@@ -1,0 +1,12 @@
+defmodule Eye2eye.Repo.Migrations.CreateOrders do
+  use Ecto.Migration
+
+  def change do
+    create table(:orders) do
+      add :user_uuid, :uuid
+      add :total_price, :decimal, precision: 15, scale: 2, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20220907112712_create_order_line_items.exs
+++ b/priv/repo/migrations/20220907112712_create_order_line_items.exs
@@ -1,0 +1,17 @@
+defmodule Eye2eye.Repo.Migrations.CreateOrderLineItems do
+  use Ecto.Migration
+
+  def change do
+    create table(:order_line_items) do
+      add :price, :decimal, precision: 15, scale: 2, null: false
+      add :quantity, :integer
+      add :order_id, references(:orders, on_delete: :nothing)
+      add :product_id, references(:products, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:order_line_items, [:order_id])
+    create index(:order_line_items, [:product_id])
+  end
+end

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -1,0 +1,35 @@
+defmodule Eye2eye.OrdersTest do
+  use Eye2eye.DataCase
+
+  alias Eye2eye.Orders
+
+  describe "orders" do
+    alias Eye2eye.Orders.Order
+
+    import Eye2eye.OrdersFixtures
+
+    @invalid_attrs %{total_price: nil, user_uuid: nil}
+
+    test "list_orders/0 returns all orders" do
+      order = order_fixture()
+      assert Orders.list_orders() == [order]
+    end
+
+    test "get_order!/1 returns the order with given id" do
+      order = order_fixture()
+      assert Orders.get_order!(order.id) == order
+    end
+
+    test "create_order/1 with valid data creates a order" do
+      valid_attrs = %{total_price: "120.5", user_uuid: "7488a646-e31f-11e4-aace-600308960662"}
+
+      assert {:ok, %Order{} = order} = Orders.create_order(valid_attrs)
+      assert order.total_price == Decimal.new("120.5")
+      assert order.user_uuid == "7488a646-e31f-11e4-aace-600308960662"
+    end
+
+    test "create_order/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Orders.create_order(@invalid_attrs)
+    end
+  end
+end

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -25,12 +25,12 @@ defmodule Eye2eye.OrdersTest do
 
       assert {:ok, %Order{} = order} =
                Orders.complete_order(cart_with_one_item, valid_order_attrs)
+
       assert order.total_price == Decimal.new("120.50")
       assert order.user_uuid == cart_with_one_item.user_uuid
 
       reload_cart = ShoppingCart.get_cart_by_user_uuid(cart_with_one_item.user_uuid)
 
-      IO.puts("CART reload" <> inspect(reload_cart))
       assert reload_cart.items == []
     end
 

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -21,10 +21,10 @@ defmodule Eye2eye.OrdersTest do
     end
 
     test "create_order/1 with valid data creates a order" do
-      valid_attrs = %{total_price: "120.5", user_uuid: "7488a646-e31f-11e4-aace-600308960662"}
+      valid_attrs = %{total_price: "120.00", user_uuid: "7488a646-e31f-11e4-aace-600308960662"}
 
       assert {:ok, %Order{} = order} = Orders.create_order(valid_attrs)
-      assert order.total_price == Decimal.new("120.5")
+      assert order.total_price == Decimal.new("120.00")
       assert order.user_uuid == "7488a646-e31f-11e4-aace-600308960662"
     end
 

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -1,12 +1,12 @@
 defmodule Eye2eye.OrdersTest do
   use Eye2eye.DataCase
 
+  import Eye2eye.OrdersFixtures
+
   alias Eye2eye.Orders
 
   describe "orders" do
     alias Eye2eye.Orders.Order
-
-    import Eye2eye.OrdersFixtures
 
     @invalid_attrs %{total_price: nil, user_uuid: nil}
 
@@ -30,6 +30,34 @@ defmodule Eye2eye.OrdersTest do
 
     test "create_order/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Orders.create_order(@invalid_attrs)
+    end
+  end
+
+  describe "order_line_items" do
+    alias Eye2eye.Orders.LineItem
+
+    @invalid_attrs %{price: nil, quantity: nil}
+
+    test "list_order_line_items/0 returns all order_line_items" do
+      line_item = line_item_fixture()
+      assert Orders.list_order_line_items() == [line_item]
+    end
+
+    test "get_line_item!/1 returns the line_item with given id" do
+      line_item = line_item_fixture()
+      assert Orders.get_line_item!(line_item.id) == line_item
+    end
+
+    test "create_line_item/1 with valid data creates a line_item" do
+      valid_attrs = %{price: "120.50", quantity: 1}
+
+      assert {:ok, %LineItem{} = line_item} = Orders.create_line_item(valid_attrs)
+      assert line_item.price == Decimal.new("120.50")
+      assert line_item.quantity == 1
+    end
+
+    test "create_line_item/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Orders.create_line_item(@invalid_attrs)
     end
   end
 end

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -17,13 +17,21 @@ defmodule Eye2eye.OrdersTest do
       product = create_product_fixture()
       cart = create_cart_fixture()
       cart_with_one_item = add_cart_item_fixture(cart, product)
-      valid_order_attrs =  %{user_uuid: cart_with_one_item.user_uuid,
-    total_price: ShoppingCart.total_cart_price(cart_with_one_item)}
 
-      assert {:ok, %Order{} = order} = Orders.complete_order(cart_with_one_item, valid_order_attrs)
+      valid_order_attrs = %{
+        user_uuid: cart_with_one_item.user_uuid,
+        total_price: ShoppingCart.total_cart_price(cart_with_one_item)
+      }
 
+      assert {:ok, %Order{} = order} =
+               Orders.complete_order(cart_with_one_item, valid_order_attrs)
       assert order.total_price == Decimal.new("120.50")
-      assert order.user_uuid == cart.user_uuid
+      assert order.user_uuid == cart_with_one_item.user_uuid
+
+      reload_cart = ShoppingCart.get_cart_by_user_uuid(cart_with_one_item.user_uuid)
+
+      IO.puts("CART reload" <> inspect(reload_cart))
+      assert reload_cart.items == []
     end
 
     test "complete_order with invalid order data returns error changeset" do
@@ -31,7 +39,8 @@ defmodule Eye2eye.OrdersTest do
       cart = create_cart_fixture()
       cart_with_one_item = add_cart_item_fixture(cart, product)
 
-      assert {:error, %Ecto.Changeset{}} = Orders.complete_order(cart_with_one_item, @invalid_order_attrs)
+      assert {:error, %Ecto.Changeset{}} =
+               Orders.complete_order(cart_with_one_item, @invalid_order_attrs)
     end
   end
 end

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -265,7 +265,6 @@ defmodule Eye2eye.ShoppingCartTest do
       cart_with_one_item = add_cart_item_fixture(cart, product)
 
       assert {:ok, %Cart{} = cart} = ShoppingCart.prune_cart_items(cart_with_one_item)
-
       assert cart.items == []
     end
   end

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -104,7 +104,7 @@ defmodule Eye2eye.ShoppingCartTest do
       product = create_product_fixture()
 
       cart_with_item = add_cart_item_fixture(cart, product)
-      cart_item = hd(cart_with_item.items)
+      cart_item = List.first(cart_with_item.items)
 
       assert ShoppingCart.get_cart_item!(cart_item.id) == cart_item
     end
@@ -176,8 +176,8 @@ defmodule Eye2eye.ShoppingCartTest do
       cart = create_cart_fixture()
 
       cart_with_one_item = add_cart_item_fixture(cart, product)
-      cart_item = hd(cart_with_one_item.items)
-
+      cart_item = List.first(cart_with_one_item.items)
+  
       assert cart_item.product.price === Decimal.new("120.50")
       assert cart_item.quantity === 1
       assert ShoppingCart.total_item_price(cart_item) === Decimal.new("120.50")
@@ -189,7 +189,7 @@ defmodule Eye2eye.ShoppingCartTest do
 
       cart_with_one_item_q1 = add_cart_item_fixture(cart, product_one)
       cart_with_one_item_q2 = add_cart_item_fixture(cart, product_one)
-      cart_item = hd(cart_with_one_item_q2.items)
+      cart_item = List.first(cart_with_one_item_q2.items)
 
       assert cart_item.product.price === Decimal.new("120.50")
       assert cart_item.quantity === 2

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -61,7 +61,6 @@ defmodule Eye2eye.ShoppingCartTest do
       product_one = create_product_fixture()
       product_two = create_product_fixture(@product_two_attrs)
       cart = create_cart_fixture()
-
       cart_with_item_q1 = add_cart_item_fixture(cart, product_one)
       cart_with_item_q2 = add_cart_item_fixture(cart_with_item_q1, product_one)
       cart_with_item_q3 = add_cart_item_fixture(cart_with_item_q2, product_two)
@@ -78,7 +77,6 @@ defmodule Eye2eye.ShoppingCartTest do
     test "total_cart_price when cart has one item returns valid decimal" do
       product_one = create_product_fixture()
       cart = create_cart_fixture()
-
       cart_with_item_q1 = add_cart_item_fixture(cart, product_one)
 
       assert ShoppingCart.total_cart_price(cart_with_item_q1) === Decimal.new("120.50")
@@ -88,7 +86,6 @@ defmodule Eye2eye.ShoppingCartTest do
       product_one = create_product_fixture()
       product_two = create_product_fixture(@product_two_attrs)
       cart = create_cart_fixture()
-
       cart_with_item1 = add_cart_item_fixture(cart, product_one)
       cart_with_item2 = add_cart_item_fixture(cart_with_item1, product_two)
 
@@ -102,7 +99,6 @@ defmodule Eye2eye.ShoppingCartTest do
     test "get_cart_item!/1 returns the cart_item with given id" do
       cart = create_cart_fixture()
       product = create_product_fixture()
-
       cart_with_item = add_cart_item_fixture(cart, product)
       cart_item = List.first(cart_with_item.items)
 
@@ -174,10 +170,9 @@ defmodule Eye2eye.ShoppingCartTest do
     test "total_item_price where one cart item present with quantity one returns valid decimal" do
       product = create_product_fixture()
       cart = create_cart_fixture()
-
       cart_with_one_item = add_cart_item_fixture(cart, product)
       cart_item = List.first(cart_with_one_item.items)
-  
+
       assert cart_item.product.price === Decimal.new("120.50")
       assert cart_item.quantity === 1
       assert ShoppingCart.total_item_price(cart_item) === Decimal.new("120.50")
@@ -186,7 +181,6 @@ defmodule Eye2eye.ShoppingCartTest do
     test "total_item_price where one cart item present with quantity two returns valid decimal" do
       product_one = create_product_fixture()
       cart = create_cart_fixture()
-
       cart_with_one_item_q1 = add_cart_item_fixture(cart, product_one)
       cart_with_one_item_q2 = add_cart_item_fixture(cart, product_one)
       cart_item = List.first(cart_with_one_item_q2.items)
@@ -216,11 +210,6 @@ defmodule Eye2eye.ShoppingCartTest do
     end
 
     test "update_cart_item where one item with two quantity returns updated cart quantity" do
-      product = create_product_fixture()
-      cart = create_cart_fixture()
-      cart_with_one_item = add_cart_item_fixture(cart, product)
-      cart_item = List.first(cart_with_one_item.items)
-
       product_one = create_product_fixture()
       cart = create_cart_fixture()
       cart_with_one_item_q1 = add_cart_item_fixture(cart, product_one)

--- a/test/eye2eye/shopping_cart_test.exs
+++ b/test/eye2eye/shopping_cart_test.exs
@@ -258,5 +258,15 @@ defmodule Eye2eye.ShoppingCartTest do
       assert cart_item.quantity == 2
       assert ShoppingCart.reduce_item_quantity_by_one(cart_item).quantity == 1
     end
+
+    test "prune_cart_items returns an empty cart" do
+      product = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item = add_cart_item_fixture(cart, product)
+
+      assert {:ok, %Cart{} = cart} = ShoppingCart.prune_cart_items(cart_with_one_item)
+
+      assert cart.items == []
+    end
   end
 end

--- a/test/eye2eye_web/controllers/cart_controller_test.exs
+++ b/test/eye2eye_web/controllers/cart_controller_test.exs
@@ -43,12 +43,7 @@ defmodule Eye2eyeWeb.CartControllerTest do
       {:ok, cart_item} =
         ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
 
-      conn = get(conn, Routes.cart_path(conn, :show))
       cart_item_attrs = %{quantity: cart_item.quantity}
-
-      assert html_response(conn, 200) =~ "Product One"
-      assert html_response(conn, 200) =~ "https://images.com/1"
-      assert html_response(conn, 200) =~ "120.50"
 
       conn =
         put(
@@ -72,8 +67,6 @@ defmodule Eye2eyeWeb.CartControllerTest do
       {:ok, cart_item} =
         ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
 
-      conn = get(conn, Routes.cart_path(conn, :show))
-
       conn =
         put(
           conn,
@@ -84,7 +77,9 @@ defmodule Eye2eyeWeb.CartControllerTest do
         )
 
       assert redirected_to(conn) == Routes.cart_path(conn, :show)
+
       conn = get(conn, Routes.cart_path(conn, :show))
+
       assert html_response(conn, 200) =~ "There was an error updating your cart"
     end
 
@@ -101,6 +96,7 @@ defmodule Eye2eyeWeb.CartControllerTest do
       conn = get(conn, Routes.cart_path(conn, :show))
       cart_item = List.first(conn.assigns.cart.items)
       cart_item_attrs = %{quantity: cart_item.quantity}
+
       assert cart_item.quantity == 2
 
       conn =

--- a/test/eye2eye_web/controllers/order_controller_test.exs
+++ b/test/eye2eye_web/controllers/order_controller_test.exs
@@ -1,0 +1,80 @@
+defmodule Eye2eyeWeb.OrderControllerTest do
+  use Eye2eyeWeb.ConnCase
+
+  import Eye2eye.CatalogFixtures
+  import Eye2eye.ShoppingCartFixtures
+  import Eye2eye.OrdersFixtures
+
+  alias Eye2eye.{ShoppingCart, Catalog}
+
+  @valid_cart_item_attrs %{quantity: 1}
+
+  describe "create order" do
+
+    test "redirects to show empty cart message when order data is valid", %{conn: conn} do
+      # create product
+      product = create_product_fixture()
+      conn = get(conn, Routes.product_path(conn, :index))
+
+      # add product to cart
+      {:ok, cart_item} =
+        ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
+      IO.puts("CREATE CART ITEM after add: " <> inspect(cart_item))
+      IO.puts("CREATE CART after: " <> inspect(conn.assigns.cart))
+
+      # redirect to cart
+      conn = get(conn, Routes.cart_path(conn, :show))
+      IO.puts("CREATE CART reload: " <> inspect(conn.assigns.cart))
+
+      # click checkout - pass in cart id and attrs
+      valid_order_attrs =  %{
+        user_uuid: conn.assigns.cart.user_uuid,
+        total_price: Decimal.to_string(ShoppingCart.total_cart_price(conn.assigns.cart))
+      }
+      IO.puts("CREATE CART valid_order_attrs: " <> inspect(valid_order_attrs))
+
+      conn = post(conn, Routes.order_path(conn, :create, order_attrs: valid_order_attrs))
+
+      # # assert redirected
+      assert redirected_to(conn) == Routes.cart_path(conn, :show)
+
+      # # get /cart
+      conn = get(conn, Routes.cart_path(conn, :show))
+      IO.puts("CREATE CART htmk: " <> inspect(html_response(conn, 200)))
+      # # assert cart is empty
+      assert html_response(conn, 200) =~ "Order created successfully."
+      assert html_response(conn, 200) =~ "Your cart is empty"
+      assert html_response(conn, 200) != "Product One"
+      assert conn.assigns.cart.items == []
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      # create product
+      product = create_product_fixture()
+      conn = get(conn, Routes.product_path(conn, :index))
+
+      # add product to cart
+      {:ok, cart_item} =
+        ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
+      IO.puts("F CREATE CART ITEM after add: " <> inspect(cart_item))
+      IO.puts("F CREATE CART after: " <> inspect(conn.assigns.cart))
+
+      # redirect to cart
+      conn = get(conn, Routes.cart_path(conn, :show))
+      IO.puts("F CREATE CART reload: " <> inspect(conn.assigns.cart))
+
+      invalid_order_attrs = %{total_price: nil , user_uuid: conn.assigns.cart.user_uuid}
+
+      conn = post(conn, Routes.order_path(conn, :create, order_attrs: invalid_order_attrs))
+
+      # # assert redirected
+      assert redirected_to(conn) == Routes.cart_path(conn, :show)
+
+      # # get /cart
+      conn = get(conn, Routes.cart_path(conn, :show))
+      IO.puts("F CREATE CART htmk: " <> inspect(html_response(conn, 200)))
+      # # assert cart is empty
+      assert html_response(conn, 200) =~ "There was an error updating your cart"
+   end
+  end
+end

--- a/test/eye2eye_web/controllers/order_controller_test.exs
+++ b/test/eye2eye_web/controllers/order_controller_test.exs
@@ -10,38 +10,24 @@ defmodule Eye2eyeWeb.OrderControllerTest do
   @valid_cart_item_attrs %{quantity: 1}
 
   describe "create order" do
-
     test "redirects to show empty cart message when order data is valid", %{conn: conn} do
-      # create product
       product = create_product_fixture()
       conn = get(conn, Routes.product_path(conn, :index))
 
-      # add product to cart
       {:ok, cart_item} =
         ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
-      IO.puts("CREATE CART ITEM after add: " <> inspect(cart_item))
-      IO.puts("CREATE CART after: " <> inspect(conn.assigns.cart))
 
-      # redirect to cart
-      conn = get(conn, Routes.cart_path(conn, :show))
-      IO.puts("CREATE CART reload: " <> inspect(conn.assigns.cart))
-
-      # click checkout - pass in cart id and attrs
-      valid_order_attrs =  %{
+      valid_order_attrs = %{
         user_uuid: conn.assigns.cart.user_uuid,
         total_price: Decimal.to_string(ShoppingCart.total_cart_price(conn.assigns.cart))
       }
-      IO.puts("CREATE CART valid_order_attrs: " <> inspect(valid_order_attrs))
 
       conn = post(conn, Routes.order_path(conn, :create, order_attrs: valid_order_attrs))
 
-      # # assert redirected
       assert redirected_to(conn) == Routes.cart_path(conn, :show)
 
-      # # get /cart
       conn = get(conn, Routes.cart_path(conn, :show))
-      IO.puts("CREATE CART htmk: " <> inspect(html_response(conn, 200)))
-      # # assert cart is empty
+
       assert html_response(conn, 200) =~ "Order created successfully."
       assert html_response(conn, 200) =~ "Your cart is empty"
       assert html_response(conn, 200) != "Product One"
@@ -49,32 +35,21 @@ defmodule Eye2eyeWeb.OrderControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      # create product
       product = create_product_fixture()
       conn = get(conn, Routes.product_path(conn, :index))
 
-      # add product to cart
       {:ok, cart_item} =
         ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
-      IO.puts("F CREATE CART ITEM after add: " <> inspect(cart_item))
-      IO.puts("F CREATE CART after: " <> inspect(conn.assigns.cart))
 
-      # redirect to cart
-      conn = get(conn, Routes.cart_path(conn, :show))
-      IO.puts("F CREATE CART reload: " <> inspect(conn.assigns.cart))
-
-      invalid_order_attrs = %{total_price: nil , user_uuid: conn.assigns.cart.user_uuid}
+      invalid_order_attrs = %{total_price: nil, user_uuid: conn.assigns.cart.user_uuid}
 
       conn = post(conn, Routes.order_path(conn, :create, order_attrs: invalid_order_attrs))
 
-      # # assert redirected
       assert redirected_to(conn) == Routes.cart_path(conn, :show)
 
-      # # get /cart
       conn = get(conn, Routes.cart_path(conn, :show))
-      IO.puts("F CREATE CART htmk: " <> inspect(html_response(conn, 200)))
-      # # assert cart is empty
+
       assert html_response(conn, 200) =~ "There was an error updating your cart"
-   end
+    end
   end
 end

--- a/test/eye2eye_web/controllers/order_controller_test.exs
+++ b/test/eye2eye_web/controllers/order_controller_test.exs
@@ -17,12 +17,12 @@ defmodule Eye2eyeWeb.OrderControllerTest do
       {:ok, cart_item} =
         ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
 
-      valid_order_attrs = %{
+      valid_order_params = %{
         user_uuid: conn.assigns.cart.user_uuid,
         total_price: Decimal.to_string(ShoppingCart.total_cart_price(conn.assigns.cart))
       }
 
-      conn = post(conn, Routes.order_path(conn, :create, order_attrs: valid_order_attrs))
+      conn = post(conn, Routes.order_path(conn, :create, order: valid_order_params))
 
       assert redirected_to(conn) == Routes.cart_path(conn, :show)
 
@@ -41,9 +41,9 @@ defmodule Eye2eyeWeb.OrderControllerTest do
       {:ok, cart_item} =
         ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
 
-      invalid_order_attrs = %{total_price: nil, user_uuid: conn.assigns.cart.user_uuid}
+      invalid_order_params = %{total_price: nil, user_uuid: conn.assigns.cart.user_uuid}
 
-      conn = post(conn, Routes.order_path(conn, :create, order_attrs: invalid_order_attrs))
+      conn = post(conn, Routes.order_path(conn, :create, order: invalid_order_params))
 
       assert redirected_to(conn) == Routes.cart_path(conn, :show)
 

--- a/test/support/fixtures/orders_fixtures.ex
+++ b/test/support/fixtures/orders_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule Eye2eye.OrdersFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Eye2eye.Orders` context.
+  """
+
+  @doc """
+  Generate a order.
+  """
+  def order_fixture(attrs \\ %{}) do
+    {:ok, order} =
+      attrs
+      |> Enum.into(%{
+        total_price: "120.50",
+        user_uuid: "7488a646-e31f-11e4-aace-600308960662"
+      })
+      |> Eye2eye.Orders.create_order()
+
+    order
+  end
+end

--- a/test/support/fixtures/orders_fixtures.ex
+++ b/test/support/fixtures/orders_fixtures.ex
@@ -18,4 +18,19 @@ defmodule Eye2eye.OrdersFixtures do
 
     order
   end
+
+  @doc """
+  Generate a line_item.
+  """
+  def line_item_fixture(attrs \\ %{}) do
+    {:ok, line_item} =
+      attrs
+      |> Enum.into(%{
+        price: "120.50",
+        quantity: 1
+      })
+      |> Eye2eye.Orders.create_line_item()
+
+    line_item
+  end
 end


### PR DESCRIPTION
This PR relates to adding a [checkout feature](https://trello.com/c/ZPgvIqJ1/38-as-a-user-i-want-to-see-if-my-order-was-successful-so-i-know-my-purchase-is-complted) to the application.

The steps involved are: 
- The user click `Checkout` in `/cart` page
- Triggers POST request to '/orders' and invokes `:create` action in `OrderController` 
- `create` method takes in `order_params` and calls `complete_order`
- which validates the paramters and forms the `order_changeset` with the`line_items` which is created from mapping over `cart.items` 
- `Ecto.Multi` is used to run two transactions
   - insert `order_changeset` data into the database
   - run `prune_cart_items` to clear the cart
 - User is directed back to `/cart` to see a flash message 'Order created successfully.' and an empty cart. (this will be updated to an order page, which displays order details in the next PR)

Tests are accompanied for every new method/controller