### PR TITLE
Add order history page

### DIFF
--- a/lib/eye2eye/orders.ex
+++ b/lib/eye2eye/orders.ex
@@ -10,7 +10,7 @@ defmodule Eye2eye.Orders do
   alias Eye2eye.Orders.Order
 
   @doc """
-  Returns list of orders.
+  Returns list of orders in descending order date.
 
   ## Examples
 
@@ -20,9 +20,7 @@ defmodule Eye2eye.Orders do
   """
 
   def list_orders() do
-    Order
-    |> Repo.all()
-    |> Repo.preload(:line_items)
+    Repo.all(from(o in Order, order_by: [desc: o.inserted_at], preload: :line_items))
   end
 
   @doc """

--- a/lib/eye2eye/orders.ex
+++ b/lib/eye2eye/orders.ex
@@ -10,6 +10,22 @@ defmodule Eye2eye.Orders do
   alias Eye2eye.Orders.Order
 
   @doc """
+  Returns list of orders.
+
+  ## Examples
+
+      iex> list_orders()
+      [%Order{}, ...]
+
+  """
+
+  def list_orders() do
+    Order
+    |> Repo.all()
+    |> Repo.preload(:line_items)
+  end
+
+  @doc """
   Creates a order.
 
   First by mapping the cart items of the shopping

--- a/lib/eye2eye_web/controllers/order_controller.ex
+++ b/lib/eye2eye_web/controllers/order_controller.ex
@@ -5,7 +5,6 @@ defmodule Eye2eyeWeb.OrderController do
 
   def index(conn, _params) do
     orders = Orders.list_orders()
-    IO.puts("INDEX ORDERS: " <> inspect(orders))
     render(conn, "index.html", orders: orders)
   end
 

--- a/lib/eye2eye_web/controllers/order_controller.ex
+++ b/lib/eye2eye_web/controllers/order_controller.ex
@@ -13,7 +13,7 @@ defmodule Eye2eyeWeb.OrderController do
       {:ok, order} ->
         conn
         |> put_flash(:info, "Order created successfully.")
-        |> redirect(to: Routes.order_path(conn, :index))
+        |> redirect(to: Routes.cart_path(conn, :show))
 
       {:error, _changeset} ->
         conn

--- a/lib/eye2eye_web/controllers/order_controller.ex
+++ b/lib/eye2eye_web/controllers/order_controller.ex
@@ -3,12 +3,18 @@ defmodule Eye2eyeWeb.OrderController do
 
   alias Eye2eye.Orders
 
+  def index(conn, _params) do
+    orders = Orders.list_orders()
+    IO.puts("INDEX ORDERS: " <> inspect(orders))
+    render(conn, "index.html", orders: orders)
+  end
+
   def create(conn, %{"order" => order_params}) do
     case Orders.complete_order(conn.assigns.cart, order_params) do
-      {:ok, _order} ->
+      {:ok, order} ->
         conn
         |> put_flash(:info, "Order created successfully.")
-        |> redirect(to: Routes.cart_path(conn, :show))
+        |> redirect(to: Routes.order_path(conn, :index))
 
       {:error, _changeset} ->
         conn

--- a/lib/eye2eye_web/router.ex
+++ b/lib/eye2eye_web/router.ex
@@ -49,7 +49,7 @@ defmodule Eye2eyeWeb.Router do
     get "/cart", CartController, :show
     put "/cart", CartController, :update
 
-    resources "/orders", OrderController, only: [:create]
+    resources "/orders", OrderController, only: [:create, :index]
   end
 
   # Other scopes may use custom stacks.

--- a/lib/eye2eye_web/templates/layout/root.html.heex
+++ b/lib/eye2eye_web/templates/layout/root.html.heex
@@ -22,7 +22,7 @@
           <h1 class="margin-none "><a href="/" class="font-black">eye2eye</a></h1>
 
           <div class="font-sm row__nav ">
-            <a href="/">Order History</a>
+            <a href="/orders">Order History</a>
             <a href="/cart"> 
               🛍️ 
             <%= if @cart.items != [] do %>

--- a/lib/eye2eye_web/templates/order/index.html.heex
+++ b/lib/eye2eye_web/templates/order/index.html.heex
@@ -1,0 +1,28 @@
+<h1>Your Orders</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Order ID</th>
+      <th>Order Date</th>
+      <th>Total price</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for order <- @orders do %>
+  
+    <tr>
+      <td><%= order.id %></td>
+      <td><%=Enum.at(Enum.reverse(String.split(Date.to_string(NaiveDateTime.to_date(order.inserted_at)), "-")), 0)<>"-"<>Enum.at(Enum.reverse(String.split(Date.to_string(NaiveDateTime.to_date(order.inserted_at)), "-")), 1)<>"-"<>Enum.at(Enum.reverse(String.split(Date.to_string(NaiveDateTime.to_date(order.inserted_at)), "-")), 2) %></td>
+      <td>£<%= order.total_price %></td>
+      <td>
+        <span><%= link "Show", to: Routes.order_path(@conn, :show, order) %></span>
+      </td>
+    </tr>
+  
+<% end %>
+
+  </tbody>
+</table>

--- a/lib/eye2eye_web/templates/order/index.html.heex
+++ b/lib/eye2eye_web/templates/order/index.html.heex
@@ -15,7 +15,7 @@
   
     <tr>
       <td><%= order.id %></td>
-      <td><%=Enum.at(Enum.reverse(String.split(Date.to_string(NaiveDateTime.to_date(order.inserted_at)), "-")), 0)<>"-"<>Enum.at(Enum.reverse(String.split(Date.to_string(NaiveDateTime.to_date(order.inserted_at)), "-")), 1)<>"-"<>Enum.at(Enum.reverse(String.split(Date.to_string(NaiveDateTime.to_date(order.inserted_at)), "-")), 2) %></td>
+      <td><%= format_naive_to_date(order.inserted_at) %></td>
       <td>£<%= order.total_price %></td>
       <td>
         <span><%= link "Show", to: Routes.order_path(@conn, :show, order) %></span>

--- a/lib/eye2eye_web/views/order_view.ex
+++ b/lib/eye2eye_web/views/order_view.ex
@@ -1,3 +1,26 @@
 defmodule Eye2eyeWeb.OrderView do
   use Eye2eyeWeb, :view
+
+  def convert_naive_to_date_str(naive_date_time) do
+    date_str =
+      naive_date_time
+       |> NaiveDateTime.to_date()
+       |> Date.to_string()
+   end
+
+   def format_date(date_str) do
+      date_list = String.split(date_str, "-")
+
+      formatted_date =  Enum.at(date_list, 2) <> "-" <> Enum.at(date_list, 1) <> "-" <> Enum.at(date_list, 0)
+      formatted_date
+    end
+
+    def format_naive_to_date(naive_date_time) do
+      date =
+      naive_date_time
+        |> convert_naive_to_date_str()
+        |> format_date()
+      date
+    end
+
 end

--- a/lib/eye2eye_web/views/order_view.ex
+++ b/lib/eye2eye_web/views/order_view.ex
@@ -4,23 +4,25 @@ defmodule Eye2eyeWeb.OrderView do
   def convert_naive_to_date_str(naive_date_time) do
     date_str =
       naive_date_time
-       |> NaiveDateTime.to_date()
-       |> Date.to_string()
-   end
+      |> NaiveDateTime.to_date()
+      |> Date.to_string()
+  end
 
-   def format_date(date_str) do
-      date_list = String.split(date_str, "-")
+  def format_date(date_str) do
+    date_list = String.split(date_str, "-")
 
-      formatted_date =  Enum.at(date_list, 2) <> "-" <> Enum.at(date_list, 1) <> "-" <> Enum.at(date_list, 0)
-      formatted_date
-    end
+    formatted_date =
+      Enum.at(date_list, 2) <> "-" <> Enum.at(date_list, 1) <> "-" <> Enum.at(date_list, 0)
 
-    def format_naive_to_date(naive_date_time) do
-      date =
+    formatted_date
+  end
+
+  def format_naive_to_date(naive_date_time) do
+    date =
       naive_date_time
-        |> convert_naive_to_date_str()
-        |> format_date()
-      date
-    end
+      |> convert_naive_to_date_str()
+      |> format_date()
 
+    date
+  end
 end

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -12,6 +12,19 @@ defmodule Eye2eye.OrdersTest do
   describe "orders" do
     @invalid_order_attrs %{total_price: nil, user_uuid: nil}
 
+    test "list_orders returns all orders" do
+      product = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item = add_cart_item_fixture(cart, product)
+      IO.puts("cart_with_one_item: "<> inspect(cart_with_one_item))
+
+      order = order_fixture(cart_with_one_item)
+      IO.puts("ORDER: "<> inspect(order))
+
+      IO.puts("ORDER LIST: "<> inspect(Orders.list_orders()))
+      assert Orders.list_orders() == [order]
+    end
+
     test "complete_order with valid data creates an order and empties the shopping cart" do
       product = create_product_fixture()
       cart = create_cart_fixture()
@@ -25,6 +38,7 @@ defmodule Eye2eye.OrdersTest do
       assert {:ok, %Order{} = order} =
                Orders.complete_order(cart_with_one_item, valid_order_attrs)
 
+               IO.puts("ORDER IN CREATE ORDER: "<> inspect(order))
       assert order.total_price == Decimal.new("120.50")
       assert order.user_uuid == cart_with_one_item.user_uuid
 

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -16,12 +16,12 @@ defmodule Eye2eye.OrdersTest do
       product = create_product_fixture()
       cart = create_cart_fixture()
       cart_with_one_item = add_cart_item_fixture(cart, product)
-      IO.puts("cart_with_one_item: "<> inspect(cart_with_one_item))
+      IO.puts("cart_with_one_item: " <> inspect(cart_with_one_item))
 
       order = order_fixture(cart_with_one_item)
-      IO.puts("ORDER: "<> inspect(order))
+      IO.puts("ORDER: " <> inspect(order))
 
-      IO.puts("ORDER LIST: "<> inspect(Orders.list_orders()))
+      IO.puts("ORDER LIST: " <> inspect(Orders.list_orders()))
       assert Orders.list_orders() == [order]
     end
 
@@ -38,7 +38,7 @@ defmodule Eye2eye.OrdersTest do
       assert {:ok, %Order{} = order} =
                Orders.complete_order(cart_with_one_item, valid_order_attrs)
 
-               IO.puts("ORDER IN CREATE ORDER: "<> inspect(order))
+      IO.puts("ORDER IN CREATE ORDER: " <> inspect(order))
       assert order.total_price == Decimal.new("120.50")
       assert order.user_uuid == cart_with_one_item.user_uuid
 

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -16,12 +16,9 @@ defmodule Eye2eye.OrdersTest do
       product = create_product_fixture()
       cart = create_cart_fixture()
       cart_with_one_item = add_cart_item_fixture(cart, product)
-      IO.puts("cart_with_one_item: " <> inspect(cart_with_one_item))
 
       order = order_fixture(cart_with_one_item)
-      IO.puts("ORDER: " <> inspect(order))
 
-      IO.puts("ORDER LIST: " <> inspect(Orders.list_orders()))
       assert Orders.list_orders() == [order]
     end
 
@@ -38,7 +35,6 @@ defmodule Eye2eye.OrdersTest do
       assert {:ok, %Order{} = order} =
                Orders.complete_order(cart_with_one_item, valid_order_attrs)
 
-      IO.puts("ORDER IN CREATE ORDER: " <> inspect(order))
       assert order.total_price == Decimal.new("120.50")
       assert order.user_uuid == cart_with_one_item.user_uuid
 

--- a/test/eye2eye_web/controllers/order_controller_test.exs
+++ b/test/eye2eye_web/controllers/order_controller_test.exs
@@ -16,7 +16,6 @@ defmodule Eye2eyeWeb.OrderControllerTest do
   describe "index" do
     test "lists all orders", %{conn: conn} do
       conn = get(conn, Routes.order_path(conn, :index))
-      # IO.puts(" HTML: " <> inspect(conn.html_response))
       assert html_response(conn, 200) =~ "Your Orders"
     end
   end

--- a/test/eye2eye_web/controllers/order_controller_test.exs
+++ b/test/eye2eye_web/controllers/order_controller_test.exs
@@ -13,6 +13,14 @@ defmodule Eye2eyeWeb.OrderControllerTest do
     %{product: product}
   end
 
+  describe "index" do
+    test "lists all orders", %{conn: conn} do
+      conn = get(conn, Routes.order_path(conn, :index))
+      # IO.puts(" HTML: " <> inspect(conn.html_response))
+      assert html_response(conn, 200) =~ "Your Orders"
+    end
+  end
+
   describe "create order" do
     setup [:create_product]
 

--- a/test/eye2eye_web/views/order_view_test.exs
+++ b/test/eye2eye_web/views/order_view_test.exs
@@ -1,0 +1,21 @@
+defmodule Eye2eyeWeb.OrderViewTest do
+  use Eye2eyeWeb.ConnCase, async: true
+
+  alias Eye2eyeWeb.OrderView
+
+  test "convert_naive_to_date_str returns a date string" do
+
+    assert OrderView.convert_naive_to_date_str(~N[2022-09-08 14:57:08]) == "2022-09-08"
+  end
+
+  test "format_date returns a datetime string formatted to day-month-year" do
+
+    assert OrderView.format_date("2022-09-08") == "08-09-2022"
+  end
+
+  test "format_naive_to_date returns a date string" do
+    naive_datetime =  ~N[2022-09-08 14:57:08]
+
+    assert OrderView.format_naive_to_date(naive_datetime) == "08-09-2022"
+  end
+end

--- a/test/eye2eye_web/views/order_view_test.exs
+++ b/test/eye2eye_web/views/order_view_test.exs
@@ -4,17 +4,15 @@ defmodule Eye2eyeWeb.OrderViewTest do
   alias Eye2eyeWeb.OrderView
 
   test "convert_naive_to_date_str returns a date string" do
-
     assert OrderView.convert_naive_to_date_str(~N[2022-09-08 14:57:08]) == "2022-09-08"
   end
 
   test "format_date returns a datetime string formatted to day-month-year" do
-
     assert OrderView.format_date("2022-09-08") == "08-09-2022"
   end
 
   test "format_naive_to_date returns a date string" do
-    naive_datetime =  ~N[2022-09-08 14:57:08]
+    naive_datetime = ~N[2022-09-08 14:57:08]
 
     assert OrderView.format_naive_to_date(naive_datetime) == "08-09-2022"
   end

--- a/test/support/fixtures/orders_fixtures.ex
+++ b/test/support/fixtures/orders_fixtures.ex
@@ -12,12 +12,13 @@ defmodule Eye2eye.OrdersFixtures do
 
   """
 
-  def order_fixture(cart, attrs\\%{}) do
-  attrs = %{
-        user_uuid: cart.user_uuid,
-        total_price: ShoppingCart.total_cart_price(cart)
-      }
-      {:ok, order } = Eye2eye.Orders.complete_order(cart, attrs)
-      order
+  def order_fixture(cart, attrs \\ %{}) do
+    attrs = %{
+      user_uuid: cart.user_uuid,
+      total_price: ShoppingCart.total_cart_price(cart)
+    }
+
+    {:ok, order} = Eye2eye.Orders.complete_order(cart, attrs)
+    order
   end
 end

--- a/test/support/fixtures/orders_fixtures.ex
+++ b/test/support/fixtures/orders_fixtures.ex
@@ -3,4 +3,21 @@ defmodule Eye2eye.OrdersFixtures do
   This module defines test helpers for creating
   entities via the `Eye2eye.Orders` context.
   """
+
+  alias Eye2eye.ShoppingCart
+  alias Eye2eye.Orders
+
+  @doc """
+  Generates an order
+
+  """
+
+  def order_fixture(cart, attrs\\%{}) do
+  attrs = %{
+        user_uuid: cart.user_uuid,
+        total_price: ShoppingCart.total_cart_price(cart)
+      }
+      {:ok, order } = Eye2eye.Orders.complete_order(cart, attrs)
+      order
+  end
 end


### PR DESCRIPTION
This PR focuses on the [order history page](https://trello.com/c/fE8pFKjP/28-as-a-user-of-the-ecommerce-web-app-i-want-to-be-able-to-see-all-previous-orders-with-details-so-that-i-know-what-i-have-purchase)

Brief: The user should be able to go to a ‘Previous orders’ page which pulls this data from the database.

- The `Orders.list_orders()` method query's postgres db for all orders, in descending order of inserted_at and preloads 'line_items' 
- The `OrderController` index action loads these order onto the page
- `orders/index.html` renders a table with four columns (order id, order date, total price, show link), where order data has been dynamically inserted. 
- Date has been formatted via `format_naive_to_date` method in `order_view.ex` 