### PR TITLE
Add order summary page

### DIFF
--- a/assets/css/phoenix.css
+++ b/assets/css/phoenix.css
@@ -35,6 +35,10 @@ select {
   width: auto;
 }
 
+.width-lg{
+  width: 90vw;
+}
+
 /* Phoenix promo and logo */
 .phx-hero {
   text-align: center;
@@ -86,20 +90,13 @@ header nav li {
   text-align: right;
   white-space: nowrap;
 }
-/* header nav ul {
-  margin: 1rem;
-  margin-top: 0;
-} */
-/* header nav a {
-  display: block;
-} */
 
 .row__nav {
   display: flex;
   justify-content: flex-end;
-  width: 50vw;
+  /* width: 50vw; */
   gap: 1rem;
-  margin: 0 auto;
+  /* margin: 0 auto; */
 }
 
 .margin-none {
@@ -196,19 +193,7 @@ p, ul {
 }
 
 @media (min-width: 40.0rem) { /* Small devices (landscape phones, 576px and up) */
-  header section {
-    flex-direction: row;
-  }
-  header nav ul {
-    margin: 1rem;
-  }
-  .phx-logo {
-    flex-basis: 527px;
-    margin: 2rem 1rem;
-  }
-
   .row__nav {
-    max-width: 60rem;
     font-size: 2rem;
   }
 }

--- a/assets/css/phoenix.css
+++ b/assets/css/phoenix.css
@@ -121,6 +121,11 @@ header nav li {
   text-align: center;
 }
 
+.text-right{
+  text-align: right;
+}
+
+
 .color{
   color:#0069d9;
 }
@@ -177,6 +182,12 @@ p, ul {
   margin-bottom: 2.5rem;
 }
 
+.links-container{
+  display: flex;
+  justify-content: center;
+  gap:1rem;
+  font-size: 1.1rem;
+}
 @media (min-width: 40.0rem) { /* Small devices (landscape phones, 576px and up) */
   header section {
     flex-direction: row;

--- a/assets/css/phoenix.css
+++ b/assets/css/phoenix.css
@@ -109,6 +109,12 @@ header nav li {
 .font-sm{
   font-size: 1rem;
 }
+.font-md{
+  font-size: 1.1rem;
+}
+.font-lg{
+  font-size: 1.3rem;
+}
 
 .gap-sm{
   display: flex;
@@ -188,6 +194,7 @@ p, ul {
   gap:1rem;
   font-size: 1.1rem;
 }
+
 @media (min-width: 40.0rem) { /* Small devices (landscape phones, 576px and up) */
   header section {
     flex-direction: row;

--- a/assets/css/phoenix.css
+++ b/assets/css/phoenix.css
@@ -13,7 +13,38 @@ blockquote{border-left:0.3rem solid #d1d1d1;margin-left:0;margin-right:0;padding
 blockquote *:last-child{margin-bottom:0}.button,
 button,input[type='button'],input[type='reset'],input[type='submit']{background-color:#0069d9;border:0.1rem solid #0069d9;border-radius:.4rem;color:#fff;cursor:pointer;display:inline-block;font-size:1.1rem;font-weight:700;height:3.8rem;letter-spacing:.1rem;line-height:3.8rem;padding:0 3.0rem;text-align:center;text-decoration:none;text-transform:uppercase;white-space:nowrap}
 .button:focus,.button:hover,button:focus,button:hover,input[type='button']:focus,input[type='button']:hover,input[type='reset']:focus,input[type='reset']:hover,input[type='submit']:focus,input[type='submit']:hover{background-color:#606c76;border-color:#606c76;color:#fff;outline:0}.button[disabled],button[disabled],input[type='button'][disabled],input[type='reset'][disabled],input[type='submit'][disabled]{cursor:default;opacity:.5}
-.button[disabled]:focus,.button[disabled]:hover,button[disabled]:focus,button[disabled]:hover,input[type='button'][disabled]:focus,input[type='button'][disabled]:hover,input[type='reset'][disabled]:focus,input[type='reset'][disabled]:hover,input[type='submit'][disabled]:focus,input[type='submit'][disabled]:hover{background-color:#0069d9;border-color:#0069d9}.button.button-outline,button.button-outline,input[type='button'].button-outline,input[type='reset'].button-outline,input[type='submit'].button-outline{background-color:transparent;color:#0069d9}.button.button-outline:focus,.button.button-outline:hover,button.button-outline:focus,button.button-outline:hover,input[type='button'].button-outline:focus,input[type='button'].button-outline:hover,input[type='reset'].button-outline:focus,input[type='reset'].button-outline:hover,input[type='submit'].button-outline:focus,input[type='submit'].button-outline:hover{background-color:transparent;border-color:#606c76;color:#606c76}.button.button-outline[disabled]:focus,.button.button-outline[disabled]:hover,button.button-outline[disabled]:focus,button.button-outline[disabled]:hover,input[type='button'].button-outline[disabled]:focus,input[type='button'].button-outline[disabled]:hover,input[type='reset'].button-outline[disabled]:focus,input[type='reset'].button-outline[disabled]:hover,input[type='submit'].button-outline[disabled]:focus,input[type='submit'].button-outline[disabled]:hover{border-color:inherit;color:#0069d9}.button.button-clear,button.button-clear,input[type='button'].button-clear,input[type='reset'].button-clear,input[type='submit'].button-clear{background-color:transparent;border-color:transparent;color:#0069d9}.button.button-clear:focus,.button.button-clear:hover,button.button-clear:focus,button.button-clear:hover,input[type='button'].button-clear:focus,input[type='button'].button-clear:hover,input[type='reset'].button-clear:focus,input[type='reset'].button-clear:hover,input[type='submit'].button-clear:focus,input[type='submit'].button-clear:hover{background-color:transparent;border-color:transparent;color:#606c76}.button.button-clear[disabled]:focus,.button.button-clear[disabled]:hover,button.button-clear[disabled]:focus,button.button-clear[disabled]:hover,input[type='button'].button-clear[disabled]:focus,input[type='button'].button-clear[disabled]:hover,input[type='reset'].button-clear[disabled]:focus,input[type='reset'].button-clear[disabled]:hover,input[type='submit'].button-clear[disabled]:focus,input[type='submit'].button-clear[disabled]:hover{color:#0069d9}code{background:#f4f5f6;border-radius:.4rem;font-size:86%;margin:0 .2rem;padding:.2rem .5rem;white-space:nowrap}pre{background:#f4f5f6;border-left:0.3rem solid #0069d9;overflow-y:hidden}pre>code{border-radius:0;display:block;padding:1rem 1.5rem;white-space:pre}hr{border:0;border-top:0.1rem solid #f4f5f6;margin:3.0rem 0}input[type='color'],input[type='date'],input[type='datetime'],input[type='datetime-local'],input[type='email'],input[type='month'],input[type='number'],input[type='password'],input[type='search'],input[type='tel'],input[type='text'],input[type='url'],input[type='week'],input:not([type]),textarea,select{-webkit-appearance:none;background-color:transparent;border:0.1rem solid #d1d1d1;border-radius:.4rem;box-shadow:none;box-sizing:inherit;height:3.8rem;padding:.6rem 1.0rem .7rem;width:100%}input[type='color']:focus,input[type='date']:focus,input[type='datetime']:focus,input[type='datetime-local']:focus,input[type='email']:focus,input[type='month']:focus,input[type='number']:focus,input[type='password']:focus,input[type='search']:focus,input[type='tel']:focus,input[type='text']:focus,input[type='url']:focus,input[type='week']:focus,input:not([type]):focus,textarea:focus,select:focus{border-color:#0069d9;outline:0}select{background:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 8" width="30"><path fill="%23d1d1d1" d="M0,0l6,8l6-8"/></svg>') center right no-repeat;padding-right:3.0rem}select:focus{background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 8" width="30"><path fill="%230069d9" d="M0,0l6,8l6-8"/></svg>')}select[multiple]{background:none;height:auto}textarea{min-height:6.5rem}label,legend{display:block;font-size:1.6rem;font-weight:700;margin-bottom:.5rem}fieldset{border-width:0;padding:0}input[type='checkbox'],input[type='radio']{display:inline}.label-inline{display:inline-block;font-weight:normal;margin-left:.5rem}.container{margin:0 auto;max-width:112.0rem;padding:0 2.0rem;position:relative;width:100%}.row{display:flex;flex-direction:column;padding:0;width:100%}.row.row-no-padding{padding:0}.row.row-no-padding>.column{padding:0}.row.row-wrap{flex-wrap:wrap}.row.row-top{align-items:flex-start}.row.row-bottom{align-items:flex-end}.row.row-center{align-items:center}.row.row-stretch{align-items:stretch}.row.row-baseline{align-items:baseline}.row .column{display:block;flex:1 1 auto;margin-left:0;max-width:100%;width:100%}.row .column.column-offset-10{margin-left:10%}.row .column.column-offset-20{margin-left:20%}.row .column.column-offset-25{margin-left:25%}.row .column.column-offset-33,.row .column.column-offset-34{margin-left:33.3333%}.row .column.column-offset-40{margin-left:40%}.row .column.column-offset-50{margin-left:50%}.row .column.column-offset-60{margin-left:60%}.row .column.column-offset-66,.row .column.column-offset-67{margin-left:66.6666%}.row .column.column-offset-75{margin-left:75%}.row .column.column-offset-80{margin-left:80%}.row .column.column-offset-90{margin-left:90%}.row .column.column-10{flex:0 0 10%;max-width:10%}.row .column.column-20{flex:0 0 20%;max-width:20%}.row .column.column-25{flex:0 0 25%;max-width:25%}.row .column.column-33,.row .column.column-34{flex:0 0 33.3333%;max-width:33.3333%}.row .column.column-40{flex:0 0 40%;max-width:40%}.row .column.column-50{flex:0 0 50%;max-width:50%}.row .column.column-60{flex:0 0 60%;max-width:60%}.row .column.column-66,.row .column.column-67{flex:0 0 66.6666%;max-width:66.6666%}.row .column.column-75{flex:0 0 75%;max-width:75%}.row .column.column-80{flex:0 0 80%;max-width:80%}.row .column.column-90{flex:0 0 90%;max-width:90%}.row .column .column-top{align-self:flex-start}.row .column .column-bottom{align-self:flex-end}.row .column .column-center{align-self:center}@media (min-width: 40rem){.row{flex-direction:row;margin-left:-1.0rem;width:calc(100% + 2.0rem)}.row .column{margin-bottom:inherit;padding:0 1.0rem}}a{color:#0069d9;text-decoration:none}a:focus,a:hover{color:#606c76}dl,ol,ul{list-style:none;margin-top:0;padding-left:0}dl dl,dl ol,dl ul,ol dl,ol ol,ol ul,ul dl,ul ol,ul ul{font-size:90%;margin:1.5rem 0 1.5rem 3.0rem}ol{list-style:decimal inside}ul{list-style:circle inside}.button,button,dd,dt,li{margin-bottom:1.0rem}fieldset,input,select,textarea{margin-bottom:1.5rem}blockquote,dl,figure,form,ol,p,pre,table,ul{margin-bottom:2.5rem}table{border-spacing:0;display:block;overflow-x:auto;text-align:left;width:100%}td,th{border-bottom:0.1rem solid #e1e1e1;padding:1.2rem 1.5rem}td:first-child,th:first-child{padding-left:0}td:last-child,th:last-child{padding-right:0}@media (min-width: 40rem){table{display:table;overflow-x:initial}}b,strong{font-weight:bold}p{margin-top:0}h1,h2,h3,h4,h5,h6{font-weight:300;letter-spacing:-.1rem;margin-bottom:2.0rem;margin-top:0}h1{font-size:4.6rem;line-height:1.2}h2{font-size:3.6rem;line-height:1.25}h3{font-size:2.8rem;line-height:1.3}h4{font-size:2.2rem;letter-spacing:-.08rem;line-height:1.35}h5{font-size:1.8rem;letter-spacing:-.05rem;line-height:1.5}h6{font-size:1.6rem;letter-spacing:0;line-height:1.4}img{max-width:100%}.clearfix:after{clear:both;content:' ';display:table}.float-left{float:left}.float-right{float:right}
+.button[disabled]:focus,.button[disabled]:hover,button[disabled]:focus,button[disabled]:hover,input[type='button'][disabled]:focus,input[type='button'][disabled]:hover,input[type='reset'][disabled]:focus,input[type='reset'][disabled]:hover,input[type='submit'][disabled]:focus,input[type='submit'][disabled]:hover{background-color:#0069d9;border-color:#0069d9}.button.button-outline,button.button-outline,input[type='button'].button-outline,input[type='reset'].button-outline,input[type='submit'].button-outline{background-color:transparent;color:#0069d9}.button.button-outline:focus,.button.button-outline:hover,button.button-outline:focus,button.button-outline:hover,input[type='button'].button-outline:focus,input[type='button'].button-outline:hover,input[type='reset'].button-outline:focus,input[type='reset'].button-outline:hover,input[type='submit'].button-outline:focus,input[type='submit'].button-outline:hover{background-color:transparent;border-color:#606c76;color:#606c76}.button.button-outline[disabled]:focus,.button.button-outline[disabled]:hover,button.button-outline[disabled]:focus,button.button-outline[disabled]:hover,input[type='button'].button-outline[disabled]:focus,input[type='button'].button-outline[disabled]:hover,input[type='reset'].button-outline[disabled]:focus,input[type='reset'].button-outline[disabled]:hover,input[type='submit'].button-outline[disabled]:focus,input[type='submit'].button-outline[disabled]:hover{border-color:inherit;color:#0069d9}.button.button-clear,button.button-clear,input[type='button'].button-clear,input[type='reset'].button-clear,input[type='submit'].button-clear{background-color:transparent;border-color:transparent;color:#0069d9}.button.button-clear:focus,.button.button-clear:hover,button.button-clear:focus,button.button-clear:hover,input[type='button'].button-clear:focus,input[type='button'].button-clear:hover,input[type='reset'].button-clear:focus,input[type='reset'].button-clear:hover,input[type='submit'].button-clear:focus,input[type='submit'].button-clear:hover{background-color:transparent;border-color:transparent;color:#606c76}.button.button-clear[disabled]:focus,.button.button-clear[disabled]:hover,button.button-clear[disabled]:focus,button.button-clear[disabled]:hover,input[type='button'].button-clear[disabled]:focus,input[type='button'].button-clear[disabled]:hover,input[type='reset'].button-clear[disabled]:focus,input[type='reset'].button-clear[disabled]:hover,input[type='submit'].button-clear[disabled]:focus,input[type='submit'].button-clear[disabled]:hover{color:#0069d9}code{background:#f4f5f6;border-radius:.4rem;font-size:86%;margin:0 .2rem;padding:.2rem .5rem;white-space:nowrap}pre{background:#f4f5f6;border-left:0.3rem solid #0069d9;overflow-y:hidden}pre>code{border-radius:0;display:block;padding:1rem 1.5rem;white-space:pre}hr{border:0;border-top:0.1rem solid #f4f5f6;margin:3.0rem 0}input[type='color'],input[type='date'],input[type='datetime'],input[type='datetime-local'],input[type='email'],input[type='month'],input[type='number'],input[type='password'],input[type='search'],input[type='tel'],input[type='text'],input[type='url'],input[type='week'],input:not([type]),textarea,select{-webkit-appearance:none;background-color:transparent;border:0.1rem solid #d1d1d1;border-radius:.4rem;box-shadow:none;box-sizing:inherit;height:3.8rem;padding:.6rem 1.0rem .7rem;width:100%}input[type='color']:focus,input[type='date']:focus,input[type='datetime']:focus,input[type='datetime-local']:focus,input[type='email']:focus,input[type='month']:focus,input[type='number']:focus,input[type='password']:focus,input[type='search']:focus,input[type='tel']:focus,input[type='text']:focus,input[type='url']:focus,input[type='week']:focus,input:not([type]):focus,textarea:focus,select:focus{border-color:#0069d9;outline:0}select{background:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 8" width="30"><path fill="%23d1d1d1" d="M0,0l6,8l6-8"/></svg>') center right no-repeat;padding-right:3.0rem}select:focus{background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 8" width="30"><path fill="%230069d9" d="M0,0l6,8l6-8"/></svg>')}select[multiple]{background:none;height:auto}textarea{min-height:6.5rem}label,legend{display:block;font-size:1.6rem;font-weight:700;margin-bottom:.5rem}fieldset{border-width:0;padding:0}input[type='checkbox'],input[type='radio']{display:inline}
+.label-inline{display:inline-block;font-weight:normal;margin-left:.5rem}
+.container{margin:0 auto;max-width:112.0rem;padding:0 2.0rem;position:relative;width:100%}
+.row{display:flex;flex-direction:column;padding:0;width:100%}
+.row.row-no-padding{padding:0}.row.row-no-padding>.column{padding:0}
+.row.row-wrap{flex-wrap:wrap}.row.row-top{align-items:flex-start}
+.row.row-bottom{align-items:flex-end}.row.row-center{align-items:center}
+.row.row-stretch{align-items:stretch}.row.row-baseline{align-items:baseline}
+.row .column{display:block;flex:1 1 auto;margin-left:0;max-width:100%;width:100%}
+.row .column.column-offset-10{margin-left:10%}.row .column.column-offset-20{margin-left:20%}
+.row .column.column-offset-25{margin-left:25%}.row .column.column-offset-33,.row .column.column-offset-34{margin-left:33.3333%}
+.row .column.column-offset-40{margin-left:40%}.row .column.column-offset-50{margin-left:50%}.row .column.column-offset-60{margin-left:60%}
+.row .column.column-offset-66,.row .column.column-offset-67{margin-left:66.6666%}.row .column.column-offset-75{margin-left:75%}
+.row .column.column-offset-80{margin-left:80%}.row .column.column-offset-90{margin-left:90%}
+.row .column.column-10{flex:0 0 10%;max-width:10%}.row .column.column-20{flex:0 0 20%;max-width:20%}
+.row .column.column-25{flex:0 0 25%;max-width:25%}.row .column.column-33,.row .column.column-34{flex:0 0 33.3333%;max-width:33.3333%}
+.row .column.column-40{flex:0 0 40%;max-width:40%}.row .column.column-50{flex:0 0 50%;max-width:50%}
+.row .column.column-60{flex:0 0 60%;max-width:60%}.row .column.column-66,.row .column.column-67{flex:0 0 66.6666%;max-width:66.6666%}
+.row .column.column-75{flex:0 0 75%;max-width:75%}.row .column.column-80{flex:0 0 80%;max-width:80%}
+.row .column.column-90{flex:0 0 90%;max-width:90%}.row .column .column-top{align-self:flex-start}
+.row .column .column-bottom{align-self:flex-end}.row .column .column-center{align-self:center}
+@media (min-width: 40rem)
+{.row{flex-direction:row;margin-left:-1.0rem;width:calc(100% + 2.0rem)}
+.row .column{margin-bottom:inherit;padding:0 1.0rem}}a{color:#0069d9;text-decoration:none}a:focus,a:hover{color:#606c76}dl,ol,ul{list-style:none;margin-top:0;padding-left:0}
+dl dl,dl ol,dl ul,ol dl,ol ol,ol ul,ul dl,ul ol,ul ul{font-size:90%;margin:1.5rem 0 1.5rem 3.0rem}ol{list-style:decimal inside}ul{list-style:circle inside}
+.button,button,dd,dt,li{margin-bottom:1.0rem}fieldset,input,select,textarea{margin-bottom:1.5rem}blockquote,dl,figure,form,ol,p,pre,table,ul{margin-bottom:2.5rem}table{border-spacing:0;display:block;overflow-x:auto;text-align:left;width:100%}
+td,th{border-bottom:0.1rem solid #e1e1e1;padding:1.2rem 1.5rem}
+td:first-child,th:first-child{padding-left:0}td:last-child,th:last-child{padding-right:0}
+@media (min-width: 40rem)
+{table{display:table;overflow-x:initial}}
+b,strong{font-weight:bold}p{margin-top:0}
+h1,h2,h3,h4,h5,h6{font-weight:300;letter-spacing:-.1rem;margin-bottom:2.0rem;margin-top:0}h1{font-size:4.6rem;line-height:1.2}h2{font-size:3.6rem;line-height:1.25}h3{font-size:2.8rem;line-height:1.3}h4{font-size:2.2rem;letter-spacing:-.08rem;line-height:1.35}h5{font-size:1.8rem;letter-spacing:-.05rem;line-height:1.5}h6{font-size:1.6rem;letter-spacing:0;line-height:1.4}img{max-width:100%}.clearfix:after{clear:both;content:' ';display:table}.float-left{float:left}.float-right{float:right}
 
 /* General style */
 h1{font-size: 3.6rem; line-height: 1.25}
@@ -23,10 +54,8 @@ h4{font-size: 1.8rem; letter-spacing: -.05rem; line-height: 1.5}
 h5{font-size: 1.6rem; letter-spacing: 0; line-height: 1.4}
 h6{font-size: 1.4rem; letter-spacing: 0; line-height: 1.2}
 pre{padding: 1em;}
-
 .container{
   margin: 0 auto;
-  max-width: 80.0rem;
   padding: 0 2.0rem;
   position: relative;
   width: 100%
@@ -34,7 +63,6 @@ pre{padding: 1em;}
 select {
   width: auto;
 }
-
 .width-lg{
   width: 90vw;
 }
@@ -76,12 +104,6 @@ header section {
   flex-direction: row;
   justify-content: space-between;
 }
-/* header section :first-child {
-  order: 2;
-}
-header section :last-child {
-  order: 1;
-} */
 header nav ul,
 header nav li {
   margin: 0;
@@ -90,19 +112,14 @@ header nav li {
   text-align: right;
   white-space: nowrap;
 }
-
 .row__nav {
   display: flex;
   justify-content: flex-end;
-  /* width: 50vw; */
   gap: 1rem;
-  /* margin: 0 auto; */
 }
-
 .margin-none {
   margin: 0;
 }
-
 .font-sm{
   font-size: 1rem;
 }
@@ -112,29 +129,29 @@ header nav li {
 .font-lg{
   font-size: 1.3rem;
 }
-
 .gap-sm{
   display: flex;
   gap: 1rem;
   justify-content: space-between;
   align-items: baseline;
 }
-
 .text-center{
   text-align: center;
 }
-
 .text-right{
   text-align: right;
 }
-
-
 .color{
   color:#0069d9;
 }
-
 .font-black{
   color:#000000;
+}
+.flex_wrap{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap:2rem;
 }
 .btn{
   background-color:#0069d9;
@@ -142,14 +159,12 @@ header nav li {
   border-radius:.4rem;
   cursor:pointer;
 }
-
 .btn:hover{
   background-color:#e3e3e3;
   border:0.1rem solid #e3e3e3;
   border-radius:.4rem;
   cursor:pointer;
 }
-
 .cart-btn {
   color: #fff;
   padding: 0.5rem 1rem;
@@ -184,16 +199,17 @@ p, ul {
 .margin-bottom_md{
   margin-bottom: 2.5rem;
 }
-
 .links-container{
   display: flex;
   justify-content: center;
   gap:1rem;
   font-size: 1.1rem;
 }
-
-@media (min-width: 40.0rem) { /* Small devices (landscape phones, 576px and up) */
+@media (min-width: 40.0rem) { /* Tablet devices (landscape phones, 576px and up) */
   .row__nav {
     font-size: 2rem;
+  }
+  .product-container{
+    width: 300px;
   }
 }

--- a/lib/eye2eye/orders.ex
+++ b/lib/eye2eye/orders.ex
@@ -24,6 +24,26 @@ defmodule Eye2eye.Orders do
   end
 
   @doc """
+  Gets a single order by user_uuid and preload line_items and product.
+
+  Raises `Ecto.NoResultsError` if the Order does not exist.
+
+  ## Examples
+
+      iex> get_order!(1"7488a646-e31f-11e4-aace-600308960662"23)
+      %Order{}
+
+      iex> get_order!("7488a646-e31f-11e4-aace-600308960662")
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_order!(user_uuid, id) do
+    Order
+    |> Repo.get_by!(id: id, user_uuid: user_uuid)
+    |> Repo.preload(line_items: [:product])
+  end
+
+  @doc """
   Creates a order.
 
   First by mapping the cart items of the shopping

--- a/lib/eye2eye_web/controllers/order_controller.ex
+++ b/lib/eye2eye_web/controllers/order_controller.ex
@@ -13,12 +13,17 @@ defmodule Eye2eyeWeb.OrderController do
       {:ok, order} ->
         conn
         |> put_flash(:info, "Order created successfully.")
-        |> redirect(to: Routes.cart_path(conn, :show))
+        |> redirect(to: Routes.order_path(conn, :show, order))
 
       {:error, _changeset} ->
         conn
         |> put_flash(:error, "There was an error updating your cart")
         |> redirect(to: Routes.cart_path(conn, :show))
     end
+  end
+
+  def show(conn, %{"id" => id}) do
+    order = Orders.get_order!(conn.assigns.current_uuid, id)
+    render(conn, "show.html", order: order)
   end
 end

--- a/lib/eye2eye_web/router.ex
+++ b/lib/eye2eye_web/router.ex
@@ -49,7 +49,7 @@ defmodule Eye2eyeWeb.Router do
     get "/cart", CartController, :show
     put "/cart", CartController, :update
 
-    resources "/orders", OrderController, only: [:create, :index]
+    resources "/orders", OrderController, only: [:create, :index, :show]
   end
 
   # Other scopes may use custom stacks.

--- a/lib/eye2eye_web/templates/cart/show.html.heex
+++ b/lib/eye2eye_web/templates/cart/show.html.heex
@@ -24,7 +24,7 @@
       </li>
     <% end %>
   </ul>
-  <div class="checkout-container">
+  <div class="checkout-container margin-bottom_md">
     <p><b>Total</b>: £<%= ShoppingCart.total_cart_price(@cart) %></p>
     <div class="btn"> 
       <%= link "Checkout", to: Routes.order_path(@conn, :create, order: %{user_uuid: @cart.user_uuid, total_price: Decimal.to_string(ShoppingCart.total_cart_price(@cart))}), 

--- a/lib/eye2eye_web/templates/layout/root.html.heex
+++ b/lib/eye2eye_web/templates/layout/root.html.heex
@@ -18,7 +18,7 @@
   <body>
     <header>
       <section class="container">
-        <nav class="gap-sm">
+        <nav class="gap-sm width-lg">
           <h1 class="margin-none "><a href="/" class="font-black">eye2eye</a></h1>
 
           <div class="font-sm row__nav ">

--- a/lib/eye2eye_web/templates/order/index.html.heex
+++ b/lib/eye2eye_web/templates/order/index.html.heex
@@ -2,8 +2,8 @@
 <%= if @orders == [] do %>
   <p>You have not placed any orders</p>
 <% else %>
-  <table>
-    <thead>
+  <table class="text-center">
+    <thead class="font-lg">
       <tr>
         <th>Order ID</th>
         <th>Order Date</th>
@@ -12,7 +12,7 @@
         <th></th>
       </tr>
     </thead>
-    <tbody>
+    <tbody class="font-md">
   <%= for order <- @orders do %>
     
       <tr>

--- a/lib/eye2eye_web/templates/order/index.html.heex
+++ b/lib/eye2eye_web/templates/order/index.html.heex
@@ -1,28 +1,31 @@
 <h1>Your Orders</h1>
+<%= if @orders == [] do %>
+  <p>You have not placed any orders</p>
+<% else %>
+  <table>
+    <thead>
+      <tr>
+        <th>Order ID</th>
+        <th>Order Date</th>
+        <th>Total Price</th>
 
-<table>
-  <thead>
-    <tr>
-      <th>Order ID</th>
-      <th>Order Date</th>
-      <th>Total price</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+  <%= for order <- @orders do %>
+    
+      <tr>
+        <td><%= order.id %></td>
+        <td><%= format_naive_to_date(order.inserted_at) %></td>
+        <td>£<%= order.total_price %></td>
+        <td>
+          <span><%= link "Show", to: Routes.order_path(@conn, :show, order) %></span>
+        </td>
+      </tr>
+    
+  <% end %>
 
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-<%= for order <- @orders do %>
-  
-    <tr>
-      <td><%= order.id %></td>
-      <td><%= format_naive_to_date(order.inserted_at) %></td>
-      <td>£<%= order.total_price %></td>
-      <td>
-        <span><%= link "Show", to: Routes.order_path(@conn, :show, order) %></span>
-      </td>
-    </tr>
-  
+    </tbody>
+  </table>
 <% end %>
-
-  </tbody>
-</table>

--- a/lib/eye2eye_web/templates/order/show.html.heex
+++ b/lib/eye2eye_web/templates/order/show.html.heex
@@ -1,8 +1,9 @@
 <h2>Order Summary</h2>
-<p>
+<p class="margin-bottom_md">
   <strong>Order ID:</strong>
   <%= @order.id %>
 </p>
+
 <ul>
   <%= for item <- @order.line_items do %>
     <li class="cart">
@@ -12,11 +13,13 @@
     </li>
   <% end %>
 </ul>
-<p>
+<p class="text-right margin-bottom_md">
   <strong>Total price:</strong>
   £<%= @order.total_price %>
 </p>
 
-<span><%= link "Back to cart", to: Routes.cart_path(@conn, :show) %></span> | 
-<span><%= link "Continue shopping", to: Routes.product_path(@conn, :index) %></span> |
-<span><%= link "Show order history", to: Routes.order_path(@conn, :index) %></span>
+<div class="links-container margin-bottom_md">
+  <span><%= link "Back to cart", to: Routes.cart_path(@conn, :show) %></span> | 
+  <span><%= link "Continue shopping", to: Routes.product_path(@conn, :index) %></span> |
+  <span><%= link "Show order history", to: Routes.order_path(@conn, :index) %></span>
+</div>

--- a/lib/eye2eye_web/templates/order/show.html.heex
+++ b/lib/eye2eye_web/templates/order/show.html.heex
@@ -1,0 +1,22 @@
+<h2>Order Summary</h2>
+<p>
+  <strong>Order ID:</strong>
+  <%= @order.id %>
+</p>
+<ul>
+  <%= for item <- @order.line_items do %>
+    <li class="cart">
+      <img src={item.product.image_url} alt={"An image of " <> item.product.name} class="cart_img">
+      <%= item.product.name %>
+      (<%= item.quantity %>) - £<%= item.price %>
+    </li>
+  <% end %>
+</ul>
+<p>
+  <strong>Total price:</strong>
+  £<%= @order.total_price %>
+</p>
+
+<span><%= link "Back to cart", to: Routes.cart_path(@conn, :show) %></span> | 
+<span><%= link "Continue shopping", to: Routes.product_path(@conn, :index) %></span> |
+<span><%= link "Show order history", to: Routes.order_path(@conn, :index) %></span>

--- a/lib/eye2eye_web/templates/product/index.html.heex
+++ b/lib/eye2eye_web/templates/product/index.html.heex
@@ -4,7 +4,7 @@
 </section>
 
 <section class="">
-   <h2 class="text-center color">Summer 2022 Collection</h2>
+   <h2 class="text-center color">Autumn 2022 Collection</h2>
    <%= for product <- @products do %>
       <article class="column margin-bottom_md">
          <img src={product.image_url} alt={"An image of " <> product.name} >

--- a/lib/eye2eye_web/templates/product/index.html.heex
+++ b/lib/eye2eye_web/templates/product/index.html.heex
@@ -2,11 +2,12 @@
   <h1><%= gettext("Welcome to %{name}!", name: "eye2eye") %></h1>
   <p>Not just your standard eyeware company</p>
 </section>
-
-<section class="">
+<div>
    <h2 class="text-center color">Autumn 2022 Collection</h2>
+</div>
+<section class="flex_wrap">
    <%= for product <- @products do %>
-      <article class="column margin-bottom_md">
+      <article class="product-container margin-bottom_md">
          <img src={product.image_url} alt={"An image of " <> product.name} >
          <h2 class="margin-none"><%= product.name %></h2>
          <div class="gap-sm">

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -17,13 +17,26 @@ alias Eye2eye.Catalog.Product
 Repo.delete_all(Product)
 
 for i <- 1..10 do
+  product_name = [
+    "Malcom",
+    "Bobby",
+    "Franklin",
+    "Ken",
+    "Rita",
+    "Edna",
+    "Clark",
+    "Lennon",
+    "Basic",
+    "Snazzy"
+  ]
+
   img_url = [
     "https://images.unsplash.com/photo-1574258495973-f010dfbb5371?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2370&q=80",
     "https://images.unsplash.com/photo-1603578119639-798b8413d8d7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
     "https://images.unsplash.com/photo-1582478134397-2b32c067e22d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
     "https://images.unsplash.com/photo-1589176449149-71f7ea77ec25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80",
     "https://images.unsplash.com/photo-1534844978-b859e5a09ad6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1674&q=80",
-    "https://images.unsplash.com/photo-1619089661769-3101dbac9257?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1728&q=80",
+    "https://images.unsplash.com/photo-1641048927024-0e801784b4f7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTZ8fHJvdW5kJTIwZ2xhc3Nlc3xlbnwwfHwwfHw%3D&auto=format&fit=crop&w=900&q=60",
     "https://images.unsplash.com/photo-1475312775467-159e03aaa7cd?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
     "https://images.unsplash.com/photo-1511499767150-a48a237f0083?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1180&q=80",
     "https://images.unsplash.com/photo-1483412468200-72182dbbc544?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1773&q=80",
@@ -32,7 +45,7 @@ for i <- 1..10 do
 
   {:ok, _} =
     Catalog.create_product(%{
-      name: "Product #{i}",
+      name: "#{Enum.at(product_name, i - 1)}",
       image_url: "#{Enum.at(img_url, i - 1)}",
       price: "#{100 + i}"
     })

--- a/test/eye2eye/orders_test.exs
+++ b/test/eye2eye/orders_test.exs
@@ -16,10 +16,18 @@ defmodule Eye2eye.OrdersTest do
       product = create_product_fixture()
       cart = create_cart_fixture()
       cart_with_one_item = add_cart_item_fixture(cart, product)
-
       order = order_fixture(cart_with_one_item)
 
       assert Orders.list_orders() == [order]
+    end
+
+    test "get_order returns the order with given user_uuid" do
+      product = create_product_fixture()
+      cart = create_cart_fixture()
+      cart_with_one_item = add_cart_item_fixture(cart, product)
+      order = order_fixture(cart_with_one_item)
+
+      assert Orders.get_order!(cart.user_uuid, order.id).id == order.id
     end
 
     test "complete_order with valid data creates an order and empties the shopping cart" do

--- a/test/eye2eye_web/controllers/order_controller_test.exs
+++ b/test/eye2eye_web/controllers/order_controller_test.exs
@@ -5,6 +5,7 @@ defmodule Eye2eyeWeb.OrderControllerTest do
   import Eye2eye.OrdersFixtures
 
   alias Eye2eye.{ShoppingCart}
+  alias Eye2eye.Orders
 
   @valid_cart_item_attrs %{quantity: 1}
 
@@ -38,14 +39,16 @@ defmodule Eye2eyeWeb.OrderControllerTest do
       }
 
       conn = post(conn, Routes.order_path(conn, :create, order: valid_order_params))
+      assert %{id: id} = redirected_params(conn)
 
-      assert redirected_to(conn) == Routes.cart_path(conn, :show)
+      order = Orders.get_order!(conn.assigns.current_uuid, id)
+      assert redirected_to(conn) == Routes.order_path(conn, :show, order)
 
-      conn = get(conn, Routes.cart_path(conn, :show))
+      conn = get(conn, Routes.order_path(conn, :show, order))
 
       assert html_response(conn, 200) =~ "Order created successfully."
-      assert html_response(conn, 200) =~ "Your cart is empty"
-      assert html_response(conn, 200) != "Product One"
+      assert html_response(conn, 200) =~ "Order Summary"
+      assert html_response(conn, 200) =~ "Product One"
       assert conn.assigns.cart.items == []
     end
 
@@ -64,6 +67,7 @@ defmodule Eye2eyeWeb.OrderControllerTest do
       conn = get(conn, Routes.cart_path(conn, :show))
 
       assert html_response(conn, 200) =~ "There was an error updating your cart"
+      assert length(conn.assigns.cart.items) == 1
     end
   end
 end

--- a/test/eye2eye_web/controllers/order_controller_test.exs
+++ b/test/eye2eye_web/controllers/order_controller_test.exs
@@ -25,13 +25,17 @@ defmodule Eye2eyeWeb.OrderControllerTest do
 
     test "lists all orders when orders present", %{conn: conn, product: product} do
       conn = get(conn, Routes.product_path(conn, :index))
+
       {:ok, _cart_item} =
         ShoppingCart.add_item_to_cart(conn.assigns.cart, product, @valid_cart_item_attrs)
+
       conn = get(conn, Routes.cart_path(conn, :show))
+
       valid_order_params = %{
-          user_uuid: conn.assigns.cart.user_uuid,
-          total_price: Decimal.to_string(ShoppingCart.total_cart_price(conn.assigns.cart))
-        }
+        user_uuid: conn.assigns.cart.user_uuid,
+        total_price: Decimal.to_string(ShoppingCart.total_cart_price(conn.assigns.cart))
+      }
+
       conn = post(conn, Routes.order_path(conn, :create, order: valid_order_params))
 
       conn = get(conn, Routes.order_path(conn, :index))

--- a/test/eye2eye_web/controllers/product_controller_test.exs
+++ b/test/eye2eye_web/controllers/product_controller_test.exs
@@ -14,7 +14,7 @@ defmodule Eye2eyeWeb.ProductControllerTest do
     test "lists all products", %{conn: conn} do
       conn = get(conn, Routes.product_path(conn, :index))
 
-      assert html_response(conn, 200) =~ "Summer 2022 Collection"
+      assert html_response(conn, 200) =~ "Autumn 2022 Collection"
       assert html_response(conn, 200) =~ "Product One"
       assert html_response(conn, 200) =~ "https://images.com/1"
       assert html_response(conn, 200) =~ "120.50"


### PR DESCRIPTION
This PR focuses on displaying order information in an [order summary page](https://trello.com/c/LOUvHj65/9-as-a-user-i-want-to-checkout-an-order-so-i-can-purchase-the-items-i-have-selected)

It contains the following:
- order id
- line_items
  - product image
  - product name
  - quantity
  - price
- total price
- links to 
  - /cart
  - /
  - /orders

https://user-images.githubusercontent.com/69358550/189647638-c3c4ef0b-0853-4006-b0a0-8089d4db155b.mov


